### PR TITLE
Add parameterless constructor to EfCoreValueConverter templates

### DIFF
--- a/src/Vogen/Templates/AnyOtherType/AnyOtherType_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/AnyOtherType/AnyOtherType_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     text => new VOTYPE(System.Text.Json.JsonSerializer.Deserialize<VOUNDERLYINGTYPE>(text, default(System.Text.Json.JsonSerializerOptions))),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => System.Text.Json.JsonSerializer.Serialize(vo.Value, default(System.Text.Json.JsonSerializerOptions)),
+                    text => new VOTYPE(System.Text.Json.JsonSerializer.Deserialize<VOUNDERLYINGTYPE>(text, default(System.Text.Json.JsonSerializerOptions))),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/Boolean/Boolean_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Boolean/Boolean_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => new VOTYPE(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => new VOTYPE(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/Byte/Byte_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Byte/Byte_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => new VOTYPE(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => new VOTYPE(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/Char/Char_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Char/Char_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => new VOTYPE(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => new VOTYPE(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/DateTime/DateTime_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/DateTime/DateTime_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => new VOTYPE(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => new VOTYPE(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/DateTimeOffset/DateTimeOffset_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/DateTimeOffset/DateTimeOffset_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => new VOTYPE(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => new VOTYPE(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/Decimal/Decimal_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Decimal/Decimal_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => VOTYPE.From(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => VOTYPE.From(value),
+                    mappingnullHints
+                ) { }
         }

--- a/src/Vogen/Templates/Double/Double_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Double/Double_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => VOTYPE.From(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => VOTYPE.From(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/Float/Float_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Float/Float_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => VOTYPE.From(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => VOTYPE.From(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/Guid/Guid_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Guid/Guid_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => new VOTYPE(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => new VOTYPE(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/Int/Int_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Int/Int_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => new VOTYPE(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => new VOTYPE(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/Long/Long_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Long/Long_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => new VOTYPE(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => new VOTYPE(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/Short/Short_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Short/Short_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => new VOTYPE(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => new VOTYPE(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/Single/Single_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/Single/Single_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => VOTYPE.From(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => VOTYPE.From(value),
+                    null
+                ) { }
         }

--- a/src/Vogen/Templates/String/String_EfCoreValueConverter.cs
+++ b/src/Vogen/Templates/String/String_EfCoreValueConverter.cs
@@ -7,4 +7,10 @@
                     value => new VOTYPE(value),
                     mappingHints
                 ) { }
+            public EfCoreValueConverter()
+                : base(
+                    vo => vo.Value,
+                    value => new VOTYPE(value),
+                    null
+                ) { }
         }


### PR DESCRIPTION
Fixes #116 

This only updates the templates, I have seen a lot of references in the tests as well but as there are so many they are probably auto generated somehow. 
I don't want to go too deep on the frameworks used but this should at least save some copy pasting