### PR TITLE
Comments for `Instance` attribute

### DIFF
--- a/samples/Vogen.Examples/Vogen.Examples.csproj
+++ b/samples/Vogen.Examples/Vogen.Examples.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0' and '$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.17" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />

--- a/src/Vogen.SharedTypes/InstanceAttribute.cs
+++ b/src/Vogen.SharedTypes/InstanceAttribute.cs
@@ -8,6 +8,9 @@ public class InstanceAttribute : Attribute
     public object Value { get; }
 
     public string Name { get; }
+    
+    public string TripleSlashComment { get; }
 
-    public InstanceAttribute(string name, object value) => (Name, Value) = (name, value);
+    public InstanceAttribute(string name, object value, string tripleSlashComment = "") =>
+        (Name, Value, TripleSlashComment) = (name, value, tripleSlashComment);
 }

--- a/src/Vogen/BuildWorkItems.cs
+++ b/src/Vogen/BuildWorkItems.cs
@@ -240,7 +240,7 @@ internal static class BuildWorkItems
 
         foreach (AttributeData? eachAttribute in matchingAttributes)
         {
-            if (eachAttribute == null)
+            if (eachAttribute is null)
             {
                 continue;
             }
@@ -270,8 +270,10 @@ internal static class BuildWorkItems
             {
                 continue;
             }
-
-            yield return new InstanceProperties(name, value);
+            
+            var tripleSlashComment = (string?)constructorArguments[2].Value;
+            
+            yield return new InstanceProperties(name, value, tripleSlashComment ?? string.Empty);
         }
     }
 }

--- a/src/Vogen/InstanceProperties.cs
+++ b/src/Vogen/InstanceProperties.cs
@@ -2,13 +2,15 @@
 
 public class InstanceProperties
 {
-    public InstanceProperties(string name, object value)
+    public InstanceProperties(string name, object value, string tripleSlashComments)
     {
         Name = name;
         Value = value;
+        TripleSlashComments = tripleSlashComments;
     }
 
     public string Name { get; }
     
     public object Value { get; }
+    public string TripleSlashComments { get; }
 }

--- a/tests/Testbench/Program.cs
+++ b/tests/Testbench/Program.cs
@@ -5,19 +5,26 @@ using Vogen;
 
 namespace Whatever;
 
-[ValueObject(conversions: Conversions.DapperTypeHandler, underlyingType: typeof(DateTime))]
-internal sealed partial record class public_partial_classConversions_DapperTypeHandlerDateTime { }
-
-
+[ValueObject]
+[Instance("Min", 10, @"<abc>whatevs</abc>")]
+internal sealed partial record MyVo
+{
+    /// <summary>noxml</summary>
+    /// <returns>An immutable shared instance of "T:Whatever.MyVo"</returns>
+    public static int Foo = 123;
+}
 
 public class Program
 {
     public static void Main()
     {
-        //var s = Score.From(1);
-        //Console.WriteLine(s.Value);
+        var v = MyVo.Min;
+        var v2 = MyVo.Foo;
     }
 }
+
+
+
 
 // [ValueObject(underlyingType:typeof(int))]
 // public partial class NormalizedToMax128WithValidation

--- a/tests/Vogen.IntegrationTests/SnapshotTests/SnapshotTest.cs
+++ b/tests/Vogen.IntegrationTests/SnapshotTests/SnapshotTest.cs
@@ -57,9 +57,9 @@ public partial struct CustomerId
 namespace Whatever;
 
 [ValueObject(typeof(int))]
-[Instance(name: ""Unspecified"", value: -1)]
+[Instance(name: ""Unspecified"", value: -1, tripleSlashComment: ""a short description that'll show up in intellisense"")]
 [Instance(name: ""Unspecified1"", value: -2)]
-[Instance(name: ""Unspecified2"", value: -3)]
+[Instance(name: ""Unspecified2"", value: -3, tripleSlashComment: ""<some_xml>whatever</some_xml"")]
 [Instance(name: ""Unspecified3"", value: -4)]
 [Instance(name: ""Cust42"", value: 42)]
 public partial struct CustomerId

--- a/tests/Vogen.IntegrationTests/SnapshotTests/Snapshots/ValueObjectGeneratorTests.Produces_instances.verified.txt
+++ b/tests/Vogen.IntegrationTests/SnapshotTests/Snapshots/ValueObjectGeneratorTests.Produces_instances.verified.txt
@@ -122,6 +122,9 @@ namespace Whatever
         
 // instance...
 
+    
+/// <summary>a short description that'll show up in intellisense</summary>
+/// <returns>An immutable shared instance of "T:Whatever.CustomerId"</returns>
 public static CustomerId Unspecified = new CustomerId(-1);
 
 // instance...
@@ -130,6 +133,9 @@ public static CustomerId Unspecified1 = new CustomerId(-2);
 
 // instance...
 
+    
+/// <summary>&lt;some_xml&gt;whatever&lt;/some_xml</summary>
+/// <returns>An immutable shared instance of "T:Whatever.CustomerId"</returns>
 public static CustomerId Unspecified2 = new CustomerId(-3);
 
 // instance...

--- a/tests/Vogen.IntegrationTests/Vogen.IntegrationTests.csproj
+++ b/tests/Vogen.IntegrationTests/Vogen.IntegrationTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0' and '$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.17" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />

--- a/tests/Vogen.Tests/Vogen.Tests.csproj
+++ b/tests/Vogen.Tests/Vogen.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0' and '$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.17" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />


### PR DESCRIPTION
Can now add a `tripleSlashComment` argument to the `Instance` attribute for comments that show in intellisense.

Fixes #44 