### PR TITLE
Prohibit reflection with Activator.CreateInstance

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ public partial struct CustomerId {
 ```csharp
 // catches object creation expressions
 var c = new CustomerId(); // error VOG010: Type 'CustomerId' cannot be constructed with 'new' as it is prohibited
+var c = Activator.CreateInstance<CustomerId>(); // error VOG025: Type 'CustomerId' cannot be constructed via Reflection as it is prohibited.
 CustomerId c = default; // error VOG009: Type 'CustomerId' cannot be constructed with default as it is prohibited.
 var c = default(CustomerId); // error VOG009: Type 'CustomerId' cannot be constructed with default as it is prohibited.
 var c = GetCustomerId(); // error VOG010: Type 'CustomerId' cannot be constructed with 'new' as it is prohibited
@@ -648,6 +649,8 @@ To test in VS, you'll have a new 'launch profile':
 ![image showing the new launch profile for Roslyn](/docs/img/2022-02-13-05-45-54.png)
 
 Select the Vogen project as the active project, and from the dropdown, select 'Roslyn'. Then just F5 to start debugging.
+
+To debug an analyzer, write a unit test using `DisallowNewTests` as a template, not forgetting to change `CreationUsingImplicitNewAnalyzer` to the analyzer you want to test.
 
 ### Can I get it to throw my own exception?
 Yes, by specifying the exception type in either the `ValueObject` attribute, or globally, with `VogenConfiguration`.

--- a/src/Vogen/Analyzers/CreationUsingReflectionAnalyzer.cs
+++ b/src/Vogen/Analyzers/CreationUsingReflectionAnalyzer.cs
@@ -1,0 +1,95 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Vogen.Diagnostics;
+
+namespace Vogen.Analyzers;
+
+/// <summary>
+/// An analyzer that stops `CustomerId = default;`.
+/// </summary>
+[Generator]
+public class CreationUsingReflectionAnalyzer : IIncrementalGenerator
+{
+    public record struct FoundItem(Location Location, INamedTypeSymbol VoClass);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        IncrementalValuesProvider<FoundItem?> targets = GetTargets(context);
+
+        IncrementalValueProvider<(Compilation, ImmutableArray<FoundItem?>)> compilationAndTypes
+            = context.CompilationProvider.Combine(targets.Collect());
+
+        context.RegisterSourceOutput(compilationAndTypes,
+            static (spc, source) => Execute(source.Item2, spc));
+    }
+
+    private static IncrementalValuesProvider<FoundItem?> GetTargets(IncrementalGeneratorInitializationContext context)
+    {
+        return context.SyntaxProvider.CreateSyntaxProvider(
+                predicate: static (s, _) => s is InvocationExpressionSyntax,
+                transform: static (ctx, _) => TryGetTarget(ctx))
+            .Where(static m => m is not null);
+    }
+
+    private static FoundItem? TryGetTarget(GeneratorSyntaxContext ctx)
+    {
+        var syntax = (InvocationExpressionSyntax) ctx.Node;
+        var methodSymbol = (ctx.SemanticModel.GetSymbolInfo(syntax).Symbol as IMethodSymbol);
+        if (methodSymbol == null)
+        {
+            return null;
+        }
+
+        if (methodSymbol.ReceiverType?.FullNamespace() != "System") return null;
+        if (methodSymbol.ReceiverType.Name != "Activator") return null;
+
+        if (methodSymbol.Name != "CreateInstance")
+        {
+            return null;
+        }
+
+        if (methodSymbol.Parameters.Length == 0)
+        {
+            if (!methodSymbol.IsGenericMethod) return null;
+
+            var returnType = methodSymbol.ReturnType as INamedTypeSymbol;
+
+            if (returnType == null) return null;
+            
+            if (!VoFilter.IsTarget(returnType)) return null;
+            
+            return new FoundItem(syntax.GetLocation(), returnType);
+        }
+
+        if (methodSymbol.Parameters.Length == 1)
+        {
+            var childNodes = syntax.DescendantNodes().OfType<TypeOfExpressionSyntax>().ToList();
+
+            if (childNodes.Count != 1) return null;
+
+            TypeInfo xxy = ctx.SemanticModel.GetTypeInfo(childNodes[0].Type);
+
+            var syntaxNode = xxy.Type as INamedTypeSymbol;
+            
+            if (!VoFilter.IsTarget(syntaxNode)) return null;
+
+            return new FoundItem(syntax.GetLocation(), syntaxNode!);
+        }
+        
+        return null;
+    }
+
+    static void Execute(ImmutableArray<FoundItem?> typeDeclarations, SourceProductionContext context)
+    {
+        foreach (FoundItem? eachFoundItem in typeDeclarations)
+        {
+            if (eachFoundItem is not null)
+            {
+                context.ReportDiagnostic(DiagnosticItems.UsingActivatorProhibited(eachFoundItem.Value.Location, eachFoundItem.Value.VoClass.Name));
+            }
+        }
+    }
+}

--- a/src/Vogen/Diagnostics/DiagnosticCode.cs
+++ b/src/Vogen/Diagnostics/DiagnosticCode.cs
@@ -30,5 +30,6 @@ public enum DiagnosticCode
     TypeShouldBePartial = 21,
     InvalidDeserializationStrictness = 22,
     InstanceValueCannotBeConverted = 23,
-    DuplicateTypesFound = 24
+    DuplicateTypesFound = 24,
+    UsingActivatorProhibited = 25
 }

--- a/src/Vogen/Diagnostics/DiagnosticItems.cs
+++ b/src/Vogen/Diagnostics/DiagnosticItems.cs
@@ -23,6 +23,11 @@ internal static class DiagnosticItems
         "Using default of Value Objects is prohibited",
         "Type '{0}' cannot be constructed with default as it is prohibited.");
 
+    private static readonly DiagnosticDescriptor _usingActivatorProhibited = CreateDescriptor(
+        DiagnosticCode.UsingActivatorProhibited,
+        "Using Reflection to create Value Objects is prohibited",
+        "Type '{0}' cannot be constructed via Reflection as it is prohibited.");
+
     private static readonly DiagnosticDescriptor _usingNewProhibited = CreateDescriptor(
         DiagnosticCode.UsingNewProhibited,
         "Using new to create Value Objects is prohibited. Please use the From method for creation.",
@@ -151,6 +156,9 @@ internal static class DiagnosticItems
 
     public static Diagnostic UsingDefaultProhibited(Location locationOfDefaultStatement, string voClassName) => 
         BuildDiagnostic(_usingDefaultProhibited, voClassName, locationOfDefaultStatement);
+
+    public static Diagnostic UsingActivatorProhibited(Location locationOfDefaultStatement, string voClassName) => 
+        BuildDiagnostic(_usingActivatorProhibited, voClassName, locationOfDefaultStatement);
 
     public static Diagnostic UsingNewProhibited(Location location, string voClassName) => 
         BuildDiagnostic(_usingNewProhibited, voClassName, location);

--- a/tests/SmallTests/DiagnosticsTests/DisallowCreationWithReflectionTests.cs
+++ b/tests/SmallTests/DiagnosticsTests/DisallowCreationWithReflectionTests.cs
@@ -1,0 +1,89 @@
+﻿using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.CodeAnalysis;
+using Vogen.Analyzers;
+using Xunit;
+
+namespace NotSystem
+{
+    public static class Activator
+    {
+        public static T? CreateInstance<T>() => default(T);
+    }
+}
+
+namespace SmallTests.DiagnosticsTests
+{
+    public class DisallowCreationWithReflectionTests
+    {
+        [Fact]
+        public void Allows_using_Activate_CreateInstance_from_another_namespace()
+        {
+            var x = NotSystem.Activator.CreateInstance<string>();
+        }
+        
+        
+        [Theory]
+        [InlineData("partial class")]
+        [InlineData("partial struct")]
+        [InlineData("readonly partial struct")]
+        [InlineData("partial record class")]
+        [InlineData("partial record struct")]
+        [InlineData("readonly partial record struct")]
+        public void Disallows_generic_method(string type)
+        {
+            var source = $@"using Vogen;
+using System;
+
+namespace Whatever;
+
+[ValueObject(typeof(int))]
+public {type} CustomerId {{ }}
+
+var c = Activator.CreateInstance<CustomerId>();
+";
+        
+            var (diagnostics, _) = TestHelper.GetGeneratedOutput<CreationUsingReflectionAnalyzer>(source);
+
+            using var _ = new AssertionScope();
+
+            diagnostics.Should().HaveCount(1);
+            Diagnostic diagnostic = diagnostics.Single();
+
+            diagnostic.Id.Should().Be("VOG025");
+            diagnostic.ToString().Should().Match("*error VOG025: Type 'CustomerId' cannot be constructed via Reflection as it is prohibited.");
+        }
+
+        [Theory]
+        [InlineData("partial class")]
+        [InlineData("partial struct")]
+        [InlineData("readonly partial struct")]
+        [InlineData("partial record class")]
+        [InlineData("partial record struct")]
+        [InlineData("readonly partial record struct")]
+        public void Disallows_non_generic_method(string type)
+        {
+            var source = $@"using Vogen;
+using System;
+
+namespace Whatever;
+
+[ValueObject(typeof(int))]
+public {type} CustomerId {{ }}
+
+var c = Activator.CreateInstance(typeof(CustomerId));
+";
+        
+            var (diagnostics, _) = TestHelper.GetGeneratedOutput<CreationUsingReflectionAnalyzer>(source);
+
+            using var _ = new AssertionScope();
+
+            diagnostics.Should().HaveCount(1);
+            Diagnostic diagnostic = diagnostics.Single();
+
+            diagnostic.Id.Should().Be("VOG025");
+            diagnostic.ToString().Should().Match("*error VOG025: Type 'CustomerId' cannot be constructed via Reflection as it is prohibited.");
+        }
+    }
+}

--- a/tests/SmallTests/DiagnosticsTests/DisallowDefaultingTests.cs
+++ b/tests/SmallTests/DiagnosticsTests/DisallowDefaultingTests.cs
@@ -2,7 +2,6 @@
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Vogen.Analyzers;
-using Vogen.Tests;
 using Xunit;
 
 namespace SmallTests.DiagnosticsTests;

--- a/tests/SmallTests/DiagnosticsTests/LocalConfig/HappyTests.cs
+++ b/tests/SmallTests/DiagnosticsTests/LocalConfig/HappyTests.cs
@@ -1,6 +1,5 @@
 ﻿using FluentAssertions;
 using Vogen;
-using Vogen.Tests;
 using Xunit;
 
 namespace SmallTests.DiagnosticsTests.LocalConfig;

--- a/tests/SmallTests/DiagnosticsTests/LocalConfig/SadTests.cs
+++ b/tests/SmallTests/DiagnosticsTests/LocalConfig/SadTests.cs
@@ -2,7 +2,6 @@
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Vogen;
-using Vogen.Tests;
 using Xunit;
 
 namespace SmallTests.DiagnosticsTests.LocalConfig;

--- a/tests/SmallTests/DiagnosticsTests/NormalizeInputMethodTests.cs
+++ b/tests/SmallTests/DiagnosticsTests/NormalizeInputMethodTests.cs
@@ -5,7 +5,6 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.CodeAnalysis;
 using Vogen;
-using Vogen.Tests;
 using Xunit;
 
 namespace SmallTests.DiagnosticsTests;

--- a/tests/SmallTests/DiagnosticsTests/ProhibitPrimaryConstructorTests.cs
+++ b/tests/SmallTests/DiagnosticsTests/ProhibitPrimaryConstructorTests.cs
@@ -3,7 +3,6 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.CodeAnalysis;
 using Vogen.Analyzers;
-using Vogen.Tests;
 using Xunit;
 
 namespace SmallTests.DiagnosticsTests;

--- a/tests/SmallTests/RecordClassCreationTests.cs
+++ b/tests/SmallTests/RecordClassCreationTests.cs
@@ -1,3 +1,5 @@
+#pragma warning disable VOG025
+
 using System;
 using FluentAssertions;
 using Vogen;
@@ -47,7 +49,7 @@ public class RecordClassCreationTests
     [Fact]
     public void Default_vo_throws_at_runtime()
     {
-        MyRecordClassInt vo = (MyRecordClassInt) Activator.CreateInstance(typeof(MyRecordClassInt))!;
+        MyRecordClassInt vo = (MyRecordClassInt) Activator.CreateInstance(Type.GetType("Vogen.Tests.Types.MyRecordClassInt")!)!;
         Func<int> action = () => vo.Value;
 
         action.Should().Throw<ValueObjectValidationException>().WithMessage("Use of uninitialized Value Object*");

--- a/tests/SmallTests/RecordStructCreationTests.cs
+++ b/tests/SmallTests/RecordStructCreationTests.cs
@@ -47,7 +47,8 @@ public class RecordStructCreationTests
     [Fact]
     public void Default_vo_throws_at_runtime()
     {
-        MyRecordStructInt vo = (MyRecordStructInt) Activator.CreateInstance(typeof(MyRecordStructInt))!;
+        MyRecordStructInt vo =
+            (MyRecordStructInt) Activator.CreateInstance(Type.GetType("Vogen.Tests.Types.MyRecordStructInt")!)!;
         Func<int> action = () => vo.Value;
 
         action.Should().Throw<ValueObjectValidationException>().WithMessage("Use of uninitialized Value Object*");

--- a/tests/Testbench/Program.cs
+++ b/tests/Testbench/Program.cs
@@ -10,7 +10,7 @@ public class Program
     {
         await Task.CompletedTask;
 
-        var vo = Activator.CreateInstance<MyIntVo>();
+        // var vo = Activator.CreateInstance<MyIntVo>();
         //var vo = (MyIntVo)Activator.CreateInstance(typeof(MyIntVo))!;
         //Console.WriteLine(vo.Value);
     }

--- a/tests/Testbench/Program.cs
+++ b/tests/Testbench/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Vogen;
-#pragma warning disable CS0219
 
 namespace Testbench;
 
@@ -11,7 +10,9 @@ public class Program
     {
         await Task.CompletedTask;
 
-       bool b = MyIntVo.TryParse("123", out var r);
+        var vo = Activator.CreateInstance<MyIntVo>();
+        //var vo = (MyIntVo)Activator.CreateInstance(typeof(MyIntVo))!;
+        //Console.WriteLine(vo.Value);
     }
 }
 


### PR DESCRIPTION
The purpose of this change is to phohibit creation using `Activator.CreateInstance`.

Creating Value Objects with Reflection evades the validation mechanism, allowing invalid Value Objects to be live in the domain of the application.

For instance, with this Value Object:

```csharp
[ValueObject]
public partical struct CustomerId {{ }}
```

It disallows this:

```csharp
// result in error VOG025: Type 'CustomerId' cannot be constructed via Reflection as it 
var c = Activator.CreateInstance<CustomerId>(); is prohibited.
```

and...

```csharp
// result in error VOG025: Type 'CustomerId' cannot be constructed via Reflection as it 
var c = (CustomerId)Activator.CreateInstance(); 
```