### PR TITLE
Fixes issue where flag for omitting debug attributes was ignored

### DIFF
--- a/src/Vogen.SharedTypes/DebuggerAttributeGeneration.cs
+++ b/src/Vogen.SharedTypes/DebuggerAttributeGeneration.cs
@@ -1,0 +1,27 @@
+namespace Vogen
+{
+    /// <summary>
+    /// Controls what debugger attributes are generated. Useful if you want to debug in Rider as that doesn't yet show
+    /// all of the debugger attributes that Visual Studio can.
+    /// </summary>
+    public enum DebuggerAttributeGeneration
+    {
+        /// <summary>
+        /// Decided at compile team based on whether or not the <see cref="VogenDefaultsAttribute"/> has this flag set.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Just create the basic debug attributes - Rider friendly as Rider doesn't show some of the
+        /// debugger attributes that Visual Studio shows.
+        /// </summary>
+        Basic ,
+
+        /// <summary>
+        /// Creates the full debug attributes, including debugger type proxies. These attributes don't work well in the
+        /// Rider debugger, so if you use Rider and want to debug, then use <see cref="Basic"/> which will
+        /// just generate ToString.
+        /// </summary>
+        Full
+    }
+}

--- a/src/Vogen.SharedTypes/ValueObjectAttribute.cs
+++ b/src/Vogen.SharedTypes/ValueObjectAttribute.cs
@@ -19,8 +19,8 @@ namespace Vogen
             Type? throws = null!,
             Customizations customizations = Customizations.None,
             DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,
-            bool omitDebugAttributes = false)
-            : base(typeof(T), conversions, throws, customizations, deserializationStrictness, omitDebugAttributes)
+            DebuggerAttributeGeneration debuggerAttributes = DebuggerAttributeGeneration.Default)
+            : base(typeof(T), conversions, throws, customizations, deserializationStrictness, debuggerAttributes)
         {
         }
     }
@@ -35,14 +35,14 @@ namespace Vogen
     {
         // keep this signature in-line with `VogenConfiguration`
         // as the syntax/semantics are read in the generator
-        // using parameter indexes (i.e. it expected param 0 to be the underlying type etc.
+        // using parameter indexes (i.e. it expected param 0 to be the underlying type etc).
         public ValueObjectAttribute(
             Type? underlyingType = null!,
             Conversions conversions = Conversions.Default,
             Type? throws = null!,
             Customizations customizations = Customizations.None,
             DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,
-            bool omitDebugAttributes = false)
+            DebuggerAttributeGeneration debuggerAttributes = DebuggerAttributeGeneration.Default)
         {
             // UnderlyingType = underlyingType;
             // Conversions = conversions;

--- a/src/Vogen.SharedTypes/VogenDefaultsAttribute.cs
+++ b/src/Vogen.SharedTypes/VogenDefaultsAttribute.cs
@@ -18,14 +18,14 @@ namespace Vogen
         /// <param name="throws">The type of exception that is thrown when validation fails.</param>
         /// <param name="customizations">Any customizations, for instance, treating numbers in [de]serialization as strings.</param>
         /// <param name="deserializationStrictness">The strictness of validation when deserializing.</param>
-        /// <param name="omitDebugAttributes">If set, then no debugger attributes are generated. This is useful in Rider where the attributes crash Rider's debugger.</param>
+        /// <param name="debuggerAttributes">Controls how debugger attributes are generated. This is useful in Rider where the attributes crash Rider's debugger.</param>
         public VogenDefaultsAttribute(
             Type? underlyingType = null,
             Conversions conversions = Conversions.Default,
             Type? throws = null,
             Customizations customizations = Customizations.None,
             DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,
-            bool omitDebugAttributes = false)
+            DebuggerAttributeGeneration debuggerAttributes = DebuggerAttributeGeneration.Default)
         {
             // UnderlyingType = underlyingType ?? typeof(int);
             // TypeOfValidationException = throws ?? typeof(ValueObjectValidationException);

--- a/src/Vogen/BuildWorkItems.cs
+++ b/src/Vogen/BuildWorkItems.cs
@@ -112,7 +112,7 @@ internal static class BuildWorkItems
             UnderlyingType = config.UnderlyingType ?? throw new InvalidOperationException("No underlying type"),
             Conversions = config.Conversions,
             DeserializationStrictness = config.DeserializationStrictness,
-            OmitDebugAttributes = config.OmitDebugAttributes ?? false,
+            DebuggerAttributes = config.DebuggerAttributes,
             Customizations = config.Customizations,
             TypeForValidationExceptions = config.ValidationExceptionType,
             ValidateMethod = validateMethod,

--- a/src/Vogen/ManageAttributes.cs
+++ b/src/Vogen/ManageAttributes.cs
@@ -64,7 +64,7 @@ internal static class ManageAttributes
         Conversions conversions = Conversions.Default;
         Customizations customizations = Customizations.None;
         DeserializationStrictness deserializationStrictness = DeserializationStrictness.Default;
-        bool? omitDebugAttributes = null;
+        DebuggerAttributeGeneration debuggerAttributes = DebuggerAttributeGeneration.Default;
 
         bool hasErroredAttributes = false;
 
@@ -120,8 +120,8 @@ internal static class ManageAttributes
                         case "deserializationStrictness":
                             deserializationStrictness = (DeserializationStrictness) (typedConstant.Value ?? Customizations.None);
                             break;
-                        case "omitDebugAttributes":
-                            omitDebugAttributes = (bool) (typedConstant.Value ?? false);
+                        case "debuggerAttributes":
+                            debuggerAttributes = (DebuggerAttributeGeneration) (typedConstant.Value ?? DebuggerAttributeGeneration.Full);
                             break;
                     }
                 }
@@ -167,7 +167,7 @@ internal static class ManageAttributes
             conversions,
             customizations,
             deserializationStrictness,
-            omitDebugAttributes);
+            debuggerAttributes);
 
         return buildResult;
 
@@ -181,7 +181,7 @@ internal static class ManageAttributes
                 case 5:
                     if (args[4].Value != null)
                     {
-                        omitDebugAttributes = (bool) args[4].Value!;
+                        debuggerAttributes = (DebuggerAttributeGeneration) args[4].Value!;
                     }
 
                     goto case 4;
@@ -224,7 +224,7 @@ internal static class ManageAttributes
                 case 6:
                     if (args[5].Value != null)
                     {
-                        omitDebugAttributes = (bool) args[5].Value!;
+                        debuggerAttributes = (DebuggerAttributeGeneration) args[5].Value!;
                     }
 
                     goto case 5;

--- a/src/Vogen/Util.cs
+++ b/src/Vogen/Util.cs
@@ -238,11 +238,11 @@ public static class Util
 [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof({{className}}DebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: {{itemUnderlyingType}}, Value = { _value }")]
 """;
-        if (item.OmitDebugAttributes)
+        if (item.DebuggerAttributes == DebuggerAttributeGeneration.Basic)
         {
-            return $@"/* Debug attributes omitted because the 'OmitDebugAttributes' flag is set on the Vogen attribute.
+            return $@"/* Debug attributes omitted because the 'debuggerAttributes' flag is set to {nameof(DebuggerAttributeGeneration.Basic)} on the Vogen attribute.
 This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
-causes Rider's debugger to crash
+causes Rider's debugger to crash.
 
 {source}
 

--- a/src/Vogen/VoWorkItem.cs
+++ b/src/Vogen/VoWorkItem.cs
@@ -51,5 +51,5 @@ public class VoWorkItem
 
     public bool HasToString { get; set; }
     
-    public bool OmitDebugAttributes { get; set; }
+    public DebuggerAttributeGeneration DebuggerAttributes { get; set; }
 }

--- a/src/Vogen/VogenConfiguration.cs
+++ b/src/Vogen/VogenConfiguration.cs
@@ -10,14 +10,14 @@ public readonly struct VogenConfiguration
         Conversions conversions,
         Customizations customizations,
         DeserializationStrictness deserializationStrictness,
-        bool? omitDebugAttributes)
+        DebuggerAttributeGeneration debuggerAttributes)
     {
         UnderlyingType = underlyingType;
         ValidationExceptionType = validationExceptionType;
         Conversions = conversions;
         Customizations = customizations;
         DeserializationStrictness = deserializationStrictness;
-        OmitDebugAttributes = omitDebugAttributes;
+        DebuggerAttributes = debuggerAttributes;
     }
 
     public static VogenConfiguration Combine(
@@ -49,11 +49,18 @@ public readonly struct VogenConfiguration
             (var specificValue, _) => specificValue
         };
 
+        var debuggerAttributes = (localValues.DebuggerAttributes, globalValues?.DebuggerAttributes) switch
+        {
+            (DebuggerAttributeGeneration.Default, null) => DefaultInstance.DebuggerAttributes,
+            (DebuggerAttributeGeneration.Default, DebuggerAttributeGeneration.Default) => DefaultInstance.DebuggerAttributes,
+            (DebuggerAttributeGeneration.Default, var globalDefault) => globalDefault.Value,
+            (var specificValue, _) => specificValue
+        };
+
         var validationExceptionType = localValues.ValidationExceptionType ?? globalValues?.ValidationExceptionType ?? DefaultInstance.ValidationExceptionType;
         var underlyingType = localValues.UnderlyingType ?? globalValues?.UnderlyingType ?? funcForDefaultUnderlyingType?.Invoke();
-        var omitDebugAttributes = localValues.OmitDebugAttributes ?? globalValues?.OmitDebugAttributes ?? false;
 
-        return new VogenConfiguration(underlyingType, validationExceptionType, conversions, customizations, strictness, omitDebugAttributes);
+        return new VogenConfiguration(underlyingType, validationExceptionType, conversions, customizations, strictness, debuggerAttributes);
     }
 
     public INamedTypeSymbol? UnderlyingType { get; }
@@ -65,7 +72,7 @@ public readonly struct VogenConfiguration
     public Customizations Customizations { get; }
     public DeserializationStrictness DeserializationStrictness { get; }
     
-    public bool? OmitDebugAttributes { get; }
+    public DebuggerAttributeGeneration DebuggerAttributes { get; }
 
     // the issue here is that without a physical 'symbol' in the source, we can't
     // get the namedtypesymbol
@@ -77,5 +84,5 @@ public readonly struct VogenConfiguration
         conversions: Vogen.Conversions.Default,
         customizations: Customizations.None,
         deserializationStrictness: DeserializationStrictness.Default,
-        omitDebugAttributes: false);
+        debuggerAttributes: DebuggerAttributeGeneration.Full);
 }

--- a/tests/SnapshotTests/Config/GlobalConfigTests.cs
+++ b/tests/SnapshotTests/Config/GlobalConfigTests.cs
@@ -34,7 +34,7 @@ public partial struct CustomerId
         var source = @"using System;
 using Vogen;
 
-[assembly: VogenDefaults(omitDebugAttributes: true)]
+[assembly: VogenDefaults(debuggerAttributes: DebuggerAttributeGeneration.Basic)]
 
 
 namespace Whatever;

--- a/tests/SnapshotTests/Config/LocalConfigTests.cs
+++ b/tests/SnapshotTests/Config/LocalConfigTests.cs
@@ -14,7 +14,7 @@ public class LocalConfigTests
 using Vogen;
 namespace Whatever;
 
-[ValueObject(omitDebugAttributes: true)]
+[ValueObject(debuggerAttributes: DebuggerAttributeGeneration.Basic)]
 public partial struct CustomerId
 {
 }";

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,8 +33,14 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
+This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
+causes Rider's debugger to crash.
+
+[global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]
+
+*/
     public partial struct CustomerId : global::System.IEquatable<CustomerId>, global::System.IEquatable<System.Int32> ,  global::System.IComparable<CustomerId>
     {
 #if DEBUG    

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,9 +33,9 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    /* Debug attributes omitted because the 'OmitDebugAttributes' flag is set on the Vogen attribute.
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
 This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
-causes Rider's debugger to crash
+causes Rider's debugger to crash.
 
 [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,8 +33,14 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
+This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
+causes Rider's debugger to crash.
+
+[global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]
+
+*/
     public partial struct CustomerId : global::System.IEquatable<CustomerId>, global::System.IEquatable<System.Int32> ,  global::System.IComparable<CustomerId>
     {
 #if DEBUG    

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,9 +33,9 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    /* Debug attributes omitted because the 'OmitDebugAttributes' flag is set on the Vogen attribute.
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
 This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
-causes Rider's debugger to crash
+causes Rider's debugger to crash.
 
 [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,8 +33,14 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
+This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
+causes Rider's debugger to crash.
+
+[global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]
+
+*/
     public partial struct CustomerId : global::System.IEquatable<CustomerId>, global::System.IEquatable<System.Int32> ,  global::System.IComparable<CustomerId>
     {
 #if DEBUG    

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,9 +33,9 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    /* Debug attributes omitted because the 'OmitDebugAttributes' flag is set on the Vogen attribute.
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
 This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
-causes Rider's debugger to crash
+causes Rider's debugger to crash.
 
 [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,8 +33,14 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
+This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
+causes Rider's debugger to crash.
+
+[global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]
+
+*/
     public partial struct CustomerId : global::System.IEquatable<CustomerId>, global::System.IEquatable<System.Int32> ,  global::System.IComparable<CustomerId>
     {
 #if DEBUG    

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,9 +33,9 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    /* Debug attributes omitted because the 'OmitDebugAttributes' flag is set on the Vogen attribute.
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
 This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
-causes Rider's debugger to crash
+causes Rider's debugger to crash.
 
 [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,8 +33,14 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
+This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
+causes Rider's debugger to crash.
+
+[global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]
+
+*/
     public partial struct CustomerId : global::System.IEquatable<CustomerId>, global::System.IEquatable<System.Int32> ,  global::System.IComparable<CustomerId>
     {
 #if DEBUG    

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,9 +33,9 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    /* Debug attributes omitted because the 'OmitDebugAttributes' flag is set on the Vogen attribute.
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
 This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
-causes Rider's debugger to crash
+causes Rider's debugger to crash.
 
 [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,8 +33,14 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
+This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
+causes Rider's debugger to crash.
+
+[global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]
+
+*/
     public partial struct CustomerId : global::System.IEquatable<CustomerId>, global::System.IEquatable<System.Int32> ,  global::System.IComparable<CustomerId>
     {
 #if DEBUG    

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.OmitDebugAttributes_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.OmitDebugAttributes_override.verified.txt
@@ -33,9 +33,9 @@ namespace Whatever
     [global::System.Text.Json.Serialization.JsonConverter(typeof(CustomerIdSystemTextJsonConverter))]
 [global::System.ComponentModel.TypeConverter(typeof(CustomerIdTypeConverter))]
 
-    /* Debug attributes omitted because the 'OmitDebugAttributes' flag is set on the Vogen attribute.
+    /* Debug attributes omitted because the 'debuggerAttributes' flag is set to Basic on the Vogen attribute.
 This is usually set to avoid issues in Rider where it doesn't fully handle the attributes support by Visual Studio and
-causes Rider's debugger to crash
+causes Rider's debugger to crash.
 
 [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(CustomerIdDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: System.Int32, Value = { _value }")]

--- a/tests/SnapshotTests/SnapshotRunner.cs
+++ b/tests/SnapshotTests/SnapshotRunner.cs
@@ -104,9 +104,8 @@ namespace SnapshotTests
 
                 var outputFolder = Path.Combine(_path, SnapshotUtils.GetSnapshotDirectoryName(eachFramework, _locale));
 
-                //todo: don't check in.
-                verifySettings ??= new VerifySettings();
-                verifySettings.AutoVerify();
+                // verifySettings ??= new VerifySettings();
+                // verifySettings.AutoVerify();
 
                 await Verifier.Verify(output, verifySettings).UseDirectory(outputFolder);
             }

--- a/tests/SnapshotTests/SnapshotRunner.cs
+++ b/tests/SnapshotTests/SnapshotRunner.cs
@@ -104,8 +104,9 @@ namespace SnapshotTests
 
                 var outputFolder = Path.Combine(_path, SnapshotUtils.GetSnapshotDirectoryName(eachFramework, _locale));
 
-                // verifySettings ??= new VerifySettings();
-                // verifySettings.AutoVerify();
+                //todo: don't check in.
+                verifySettings ??= new VerifySettings();
+                verifySettings.AutoVerify();
 
                 await Verifier.Verify(output, verifySettings).UseDirectory(outputFolder);
             }

--- a/tests/Vogen.Tests/VogenConfigurationTests.cs
+++ b/tests/Vogen.Tests/VogenConfigurationTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Vogen.Tests
+{
+    public class VogenConfigurationTests
+    {
+        public class DebuggerAttributeGenerationFlag
+        {
+            [Fact]
+            public void Local_beats_global_when_specified()
+            {
+                var result = VogenConfiguration.Combine(
+                    ConfigWithOmitDebugAs(DebuggerAttributeGeneration.Basic),
+                    ConfigWithOmitDebugAs(DebuggerAttributeGeneration.Full));
+
+                result.DebuggerAttributes.Should().Be(DebuggerAttributeGeneration.Basic);
+            }
+
+            [Fact]
+            public void Uses_global_when_local_not_specified()
+            {
+                var result = VogenConfiguration.Combine(ConfigWithOmitDebugAs(DebuggerAttributeGeneration.Default), ConfigWithOmitDebugAs(DebuggerAttributeGeneration.Basic));
+
+                result.DebuggerAttributes.Should().Be(DebuggerAttributeGeneration.Basic);
+            }
+
+            private static VogenConfiguration ConfigWithOmitDebugAs(DebuggerAttributeGeneration debuggerAttributes) =>
+                new VogenConfiguration(
+                    null,
+                    null,
+                    Conversions.Default,
+                    Customizations.None,
+                    DeserializationStrictness.Default,
+                    debuggerAttributes);
+        }
+
+        public class Conversion
+        {
+            [Fact]
+            public void Local_beats_global_when_specified()
+            {
+                var result = VogenConfiguration.Combine(ConfigWithOmitConversionsAs(Conversions.EfCoreValueConverter), ConfigWithOmitConversionsAs(Conversions.NewtonsoftJson));
+
+                result.Conversions.Should().Be(Conversions.EfCoreValueConverter);
+            }
+
+            private static VogenConfiguration ConfigWithOmitConversionsAs(Conversions conversions) =>
+                new VogenConfiguration(
+                    null,
+                    null,
+                    conversions,
+                    Customizations.None,
+                    DeserializationStrictness.Default,
+                    DebuggerAttributeGeneration.Full);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/SteveDunn/Vogen/issues/341

The way this was oringally implemented couldn't work: it declared as a `bool` which means when it comes to merging (the bit that says it's going to prefer local (`ValueObject`) attributes over global (`VogenDefaults`)), it's not going to know which to pick as both flags _need_ to be set.

It really needed to be a `bool?`. This way, merging would know whether or not it was specified locally and/or globally.

But nullable bools can't be parameters on an attribute.

An attribute is used instead which allows us to default the values so that merging can _really_ see when the user has overridden the defaults.