### PR TITLE
fix: Newtonsoft Json converter for nullable types

### DIFF
--- a/src/Vogen/Generators/Conversions/GenerateNewtonsoftJsonConversions.cs
+++ b/src/Vogen/Generators/Conversions/GenerateNewtonsoftJsonConversions.cs
@@ -21,9 +21,12 @@ internal class GenerateNewtonsoftJsonConversions : IGenerateConversion
             return string.Empty;
         }
 
-        string code =
-            Templates.TryGetForSpecificType(item.UnderlyingType, "NewtonsoftJsonConverter") ??
-            Templates.GetForAnyType("NewtonsoftJsonConverter");
+        string? code =
+            Templates.TryGetForSpecificType(item.UnderlyingType, "NewtonsoftJsonConverter");
+        if (code is null)
+        {
+            code = item.UnderlyingType.IsValueType ? Templates.GetForAnyType("NewtonsoftJsonConverterValueType") : Templates.GetForAnyType("NewtonsoftJsonConverterReferenceType");
+        }
 
         code = code.Replace("VOTYPE", item.VoTypeName);
         code = code.Replace("VOUNDERLYINGTYPE", item.UnderlyingTypeFullName);

--- a/src/Vogen/Templates/AnyOtherType/AnyOtherType_NewtonsoftJsonConverterReferenceType.cs
+++ b/src/Vogen/Templates/AnyOtherType/AnyOtherType_NewtonsoftJsonConverterReferenceType.cs
@@ -8,13 +8,13 @@
 
             public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
             {
-                var id = (VOTYPE)value;
-                serializer.Serialize(writer, id.Value);
+                var id = ((VOTYPE)value).Value;
+                serializer.Serialize(writer, id);
             }
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                var result = serializer.Deserialize<global::System.String>(reader);
+                var result = serializer.Deserialize<VOUNDERLYINGTYPE>(reader);
                 return result != null ? VOTYPE.Deserialize(result) : null;
             }
         }

--- a/src/Vogen/Templates/AnyOtherType/AnyOtherType_NewtonsoftJsonConverterValueType.cs
+++ b/src/Vogen/Templates/AnyOtherType/AnyOtherType_NewtonsoftJsonConverterValueType.cs
@@ -14,6 +14,7 @@
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return VOTYPE.Deserialize(serializer.Deserialize<VOUNDERLYINGTYPE>(reader));
+                var result = serializer.Deserialize<VOUNDERLYINGTYPE?>(reader);
+                return result.HasValue ? VOTYPE.Deserialize(result.Value) : null;
             }
         }

--- a/tests/ConsumerTests/BugFixTests.cs
+++ b/tests/ConsumerTests/BugFixTests.cs
@@ -1,0 +1,49 @@
+using System;
+using @double;
+using @bool.@byte.@short.@float.@object;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Vogen;
+using Vogen.Tests.Types;
+using Xunit;
+
+namespace ConsumerTests.BugFixTests
+{
+    public class BugFixTests
+    {
+        /// <summary>
+        /// Fixes bug https://github.com/SteveDunn/Vogen/issues/344 where a field that is a ValueObject and is null when
+        /// deserialized by Newtonsoft.Json, throws an exception instead of returning null.
+        /// </summary>
+        [Fact]
+        public void Bug344_Can_deserialze_a_null_field()
+        {
+            var p = new Person
+            {
+                Age = Age.From(42)
+            };
+
+            var serialized = JsonConvert.SerializeObject(p);
+            var deserialized = JsonConvert.DeserializeObject<Person>(serialized)!;
+
+            deserialized.Age.Should().Be(Age.From(42));
+            deserialized.Name.Should().BeNull();
+            deserialized.Address.Should().BeNull();
+        }
+    }
+
+    public class Person
+    {
+        public Age Age { get; init; }
+        
+        public Name? Name { get; set; }
+        
+        public Address? Address { get; set; }
+    }
+    
+    [ValueObject(conversions: Conversions.NewtonsoftJson)] public partial struct Age { }
+    
+    [ValueObject(typeof(string), conversions: Conversions.NewtonsoftJson)] public partial class Name { }
+    
+    [ValueObject(typeof(string), conversions: Conversions.NewtonsoftJson)] public partial struct Address { }
+}

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestsinternal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -170,7 +170,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -156,7 +156,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.verified.txt
@@ -160,7 +160,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -188,7 +188,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -187,7 +187,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -174,7 +174,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -223,7 +223,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@decimal Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.@event Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -209,7 +209,8 @@ public @class.@record.@struct.@float.event2 Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.verified.txt
@@ -173,7 +173,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.verified.txt
@@ -184,7 +184,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@decimal>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@decimal?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__decimal.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.@event>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.@event?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.verified.txt
@@ -159,7 +159,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(serializer.Deserialize<@class.@record.@struct.@float.event2>(reader));
+                var result = serializer.Deserialize<@class.@record.@struct.@float.event2?>(reader);
+                return result.HasValue ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonrecord__struct__float__event2.Deserialize(result.Value) : null;
             }
         }
 

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.verified.txt
@@ -171,7 +171,8 @@ namespace @class
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? escapedTestspublic_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0LjJ4DNRpv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0LjJ4DNRpv.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/2HOYOY9YxJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/2HOYOY9YxJ.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4OVxptcvbi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4OVxptcvbi.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7Vmdk7Yw00.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7Vmdk7Yw00.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/8hqqDCK8dm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/8hqqDCK8dm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/AKEOkMAk9E.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BUES812MM5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BUES812MM5.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BWk4SOKZaL.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/CrOMgWpqG2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/CrOMgWpqG2.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/DYIIf5y1lA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/DYIIf5y1lA.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/De2zaakIOS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/De2zaakIOS.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/E5w3jSm8XK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/E5w3jSm8XK.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KqXsFKM8PB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KqXsFKM8PB.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LJvoyJnnrn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LJvoyJnnrn.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LxfmXAoDRy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LxfmXAoDRy.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MYIbq4Zelq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MYIbq4Zelq.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NRjVUDCvR9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NRjVUDCvR9.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QkYefIrFWm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QkYefIrFWm.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RSdIxOjWTU.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/S6gLS26ZJ4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VZMsXEXL56.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VZMsXEXL56.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Wrckye4kAE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Wrckye4kAE.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/WxSiqY1HTL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/WxSiqY1HTL.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YmDySNjmD2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YmDySNjmD2.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YoQ44VbxAj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YoQ44VbxAj.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/aaGWcHMEy7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/aaGWcHMEy7.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cOPi0Vna8H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cOPi0Vna8H.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/duFJaymH7S.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/duFJaymH7S.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eRGSjsBIVs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eRGSjsBIVs.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fjzQ8kr5e3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fjzQ8kr5e3.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/gDrlO8jPNF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/gDrlO8jPNF.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/jwnebQ77Ea.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/jwnebQ77Ea.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/mVChtsmVAc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/mVChtsmVAc.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/muj6774yT4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/muj6774yT4.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/npYbjXtTR4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/npYbjXtTR4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ttPzo56Y3z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ttPzo56Y3z.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/uDpMGGbE4J.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/uDpMGGbE4J.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/wEKYettOQO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/wEKYettOQO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xEm9mNRzTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xEm9mNRzTz.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/y2MFrMW9Xv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/y2MFrMW9Xv.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? internal_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/0Zt9V0JhWk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/0Zt9V0JhWk.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/2Zxz6JMYpm.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/2Zxz6JMYpm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/4JNS7O0k9y.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/4JNS7O0k9y.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/4gi5k2cnhO.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/4gi5k2cnhO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/5Jdwip14W4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/5Jdwip14W4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/5d92k1xTpK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/5d92k1xTpK.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/8riru9hqK8.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/8riru9hqK8.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/HGI0kSajp0.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/HGI0kSajp0.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/Jy4lCC5HMZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/Jy4lCC5HMZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/KElo1QPpSg.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/KElo1QPpSg.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/KkXuTfNkW1.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/KkXuTfNkW1.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/Mygm5N0qEU.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/Mygm5N0qEU.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/OG7GkP6ZVr.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/OG7GkP6ZVr.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/P4TTCc0Yf7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/P4TTCc0Yf7.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/PEAxX22zUN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/PEAxX22zUN.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/SJIzsboRZf.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/SJIzsboRZf.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/UGoNa5iv8W.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/UGoNa5iv8W.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/VczYkuMFxN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/VczYkuMFxN.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/Vui3UGMZoh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/Vui3UGMZoh.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/YAIRrkTGEq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/YAIRrkTGEq.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/YxUmKOqCDk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/YxUmKOqCDk.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/ZvUIVhZ0Tq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/ZvUIVhZ0Tq.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/eCMIYOrmhM.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/eCMIYOrmhM.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/eqvqJLSgNt.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/eqvqJLSgNt.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/fNGpTc98HV.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/fNGpTc98HV.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/gOCS92pR6N.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/gOCS92pR6N.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/h5DE7WWNVZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/h5DE7WWNVZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/iZF9DuDqS4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/iZF9DuDqS4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/jZxRes3tml.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/jZxRes3tml.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/mC8omC0oGh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/mC8omC0oGh.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/mUefl9vRDY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/mUefl9vRDY.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/q5akUgBzW7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/q5akUgBzW7.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/qO7jCfiuqY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/qO7jCfiuqY.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/rNY0qyjWJz.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/rNY0qyjWJz.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/sfc3wXgHuD.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/sfc3wXgHuD.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/tvyMAyAmHN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/tvyMAyAmHN.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/uWhzk4japH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/uWhzk4japH.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/v3e1ZC6VRK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/v3e1ZC6VRK.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/w62iXy02QC.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/w62iXy02QC.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/yE4PKEmLLH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/yE4PKEmLLH.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/0Zt9V0JhWk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/0Zt9V0JhWk.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/2Zxz6JMYpm.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/2Zxz6JMYpm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/4JNS7O0k9y.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/4JNS7O0k9y.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/4gi5k2cnhO.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/4gi5k2cnhO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/5Jdwip14W4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/5Jdwip14W4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/5d92k1xTpK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/5d92k1xTpK.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/8riru9hqK8.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/8riru9hqK8.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/HGI0kSajp0.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/HGI0kSajp0.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/Jy4lCC5HMZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/Jy4lCC5HMZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/KElo1QPpSg.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/KElo1QPpSg.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/KkXuTfNkW1.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/KkXuTfNkW1.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/Mygm5N0qEU.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/Mygm5N0qEU.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/OG7GkP6ZVr.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/OG7GkP6ZVr.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/P4TTCc0Yf7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/P4TTCc0Yf7.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/PEAxX22zUN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/PEAxX22zUN.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/SJIzsboRZf.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/SJIzsboRZf.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/UGoNa5iv8W.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/UGoNa5iv8W.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/VczYkuMFxN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/VczYkuMFxN.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/Vui3UGMZoh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/Vui3UGMZoh.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/YAIRrkTGEq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/YAIRrkTGEq.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/YxUmKOqCDk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/YxUmKOqCDk.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/ZvUIVhZ0Tq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/ZvUIVhZ0Tq.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/eCMIYOrmhM.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/eCMIYOrmhM.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/eqvqJLSgNt.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/eqvqJLSgNt.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/fNGpTc98HV.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/fNGpTc98HV.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/gOCS92pR6N.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/gOCS92pR6N.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/h5DE7WWNVZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/h5DE7WWNVZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/iZF9DuDqS4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/iZF9DuDqS4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/jZxRes3tml.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/jZxRes3tml.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/mC8omC0oGh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/mC8omC0oGh.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/mUefl9vRDY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/mUefl9vRDY.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/q5akUgBzW7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/q5akUgBzW7.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/qO7jCfiuqY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/qO7jCfiuqY.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/rNY0qyjWJz.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/rNY0qyjWJz.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/sfc3wXgHuD.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/sfc3wXgHuD.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/tvyMAyAmHN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/tvyMAyAmHN.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/uWhzk4japH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/uWhzk4japH.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/v3e1ZC6VRK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/v3e1ZC6VRK.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/w62iXy02QC.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/w62iXy02QC.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/yE4PKEmLLH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/yE4PKEmLLH.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/0Zt9V0JhWk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/0Zt9V0JhWk.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/2Zxz6JMYpm.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/2Zxz6JMYpm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/4JNS7O0k9y.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/4JNS7O0k9y.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/4gi5k2cnhO.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/4gi5k2cnhO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/5Jdwip14W4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/5Jdwip14W4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/5d92k1xTpK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/5d92k1xTpK.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/8riru9hqK8.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/8riru9hqK8.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/HGI0kSajp0.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/HGI0kSajp0.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/Jy4lCC5HMZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/Jy4lCC5HMZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/KElo1QPpSg.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/KElo1QPpSg.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/KkXuTfNkW1.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/KkXuTfNkW1.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/Mygm5N0qEU.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/Mygm5N0qEU.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/OG7GkP6ZVr.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/OG7GkP6ZVr.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/P4TTCc0Yf7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/P4TTCc0Yf7.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/PEAxX22zUN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/PEAxX22zUN.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/SJIzsboRZf.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/SJIzsboRZf.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/UGoNa5iv8W.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/UGoNa5iv8W.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/VczYkuMFxN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/VczYkuMFxN.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/Vui3UGMZoh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/Vui3UGMZoh.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/YAIRrkTGEq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/YAIRrkTGEq.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/YxUmKOqCDk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/YxUmKOqCDk.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/ZvUIVhZ0Tq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/ZvUIVhZ0Tq.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/eCMIYOrmhM.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/eCMIYOrmhM.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/eqvqJLSgNt.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/eqvqJLSgNt.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/fNGpTc98HV.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/fNGpTc98HV.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/gOCS92pR6N.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/gOCS92pR6N.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/h5DE7WWNVZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/h5DE7WWNVZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/iZF9DuDqS4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/iZF9DuDqS4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/jZxRes3tml.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/jZxRes3tml.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/mC8omC0oGh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/mC8omC0oGh.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/mUefl9vRDY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/mUefl9vRDY.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/q5akUgBzW7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/q5akUgBzW7.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/qO7jCfiuqY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/qO7jCfiuqY.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/rNY0qyjWJz.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/rNY0qyjWJz.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/sfc3wXgHuD.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/sfc3wXgHuD.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/tvyMAyAmHN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/tvyMAyAmHN.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/uWhzk4japH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/uWhzk4japH.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/v3e1ZC6VRK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/v3e1ZC6VRK.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/w62iXy02QC.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/w62iXy02QC.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/yE4PKEmLLH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/yE4PKEmLLH.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/0Zt9V0JhWk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/0Zt9V0JhWk.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/2Zxz6JMYpm.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/2Zxz6JMYpm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/4JNS7O0k9y.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/4JNS7O0k9y.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/4gi5k2cnhO.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/4gi5k2cnhO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/5Jdwip14W4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/5Jdwip14W4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/5d92k1xTpK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/5d92k1xTpK.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/8riru9hqK8.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/8riru9hqK8.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/HGI0kSajp0.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/HGI0kSajp0.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/Jy4lCC5HMZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/Jy4lCC5HMZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/KElo1QPpSg.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/KElo1QPpSg.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/KkXuTfNkW1.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/KkXuTfNkW1.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/Mygm5N0qEU.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/Mygm5N0qEU.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/OG7GkP6ZVr.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/OG7GkP6ZVr.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/P4TTCc0Yf7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/P4TTCc0Yf7.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/PEAxX22zUN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/PEAxX22zUN.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/SJIzsboRZf.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/SJIzsboRZf.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/UGoNa5iv8W.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/UGoNa5iv8W.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/VczYkuMFxN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/VczYkuMFxN.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/Vui3UGMZoh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/Vui3UGMZoh.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/YAIRrkTGEq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/YAIRrkTGEq.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/YxUmKOqCDk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/YxUmKOqCDk.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/ZvUIVhZ0Tq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/ZvUIVhZ0Tq.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/eCMIYOrmhM.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/eCMIYOrmhM.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/eqvqJLSgNt.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/eqvqJLSgNt.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/fNGpTc98HV.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/fNGpTc98HV.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/gOCS92pR6N.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/gOCS92pR6N.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/h5DE7WWNVZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/h5DE7WWNVZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/iZF9DuDqS4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/iZF9DuDqS4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/jZxRes3tml.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/jZxRes3tml.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/mC8omC0oGh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/mC8omC0oGh.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/mUefl9vRDY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/mUefl9vRDY.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/q5akUgBzW7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/q5akUgBzW7.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/qO7jCfiuqY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/qO7jCfiuqY.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/rNY0qyjWJz.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/rNY0qyjWJz.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/sfc3wXgHuD.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/sfc3wXgHuD.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/tvyMAyAmHN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/tvyMAyAmHN.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/uWhzk4japH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/uWhzk4japH.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/v3e1ZC6VRK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/v3e1ZC6VRK.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/w62iXy02QC.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/w62iXy02QC.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/yE4PKEmLLH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/yE4PKEmLLH.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/0Zt9V0JhWk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/0Zt9V0JhWk.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/2Zxz6JMYpm.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/2Zxz6JMYpm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/4JNS7O0k9y.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/4JNS7O0k9y.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/4gi5k2cnhO.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/4gi5k2cnhO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/5Jdwip14W4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/5Jdwip14W4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/5d92k1xTpK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/5d92k1xTpK.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/8riru9hqK8.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/8riru9hqK8.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/HGI0kSajp0.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/HGI0kSajp0.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/Jy4lCC5HMZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/Jy4lCC5HMZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/KElo1QPpSg.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/KElo1QPpSg.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/KkXuTfNkW1.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/KkXuTfNkW1.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/Mygm5N0qEU.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/Mygm5N0qEU.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/OG7GkP6ZVr.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/OG7GkP6ZVr.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/P4TTCc0Yf7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/P4TTCc0Yf7.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/PEAxX22zUN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/PEAxX22zUN.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/SJIzsboRZf.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/SJIzsboRZf.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/UGoNa5iv8W.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/UGoNa5iv8W.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/VczYkuMFxN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/VczYkuMFxN.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/Vui3UGMZoh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/Vui3UGMZoh.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/YAIRrkTGEq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/YAIRrkTGEq.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/YxUmKOqCDk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/YxUmKOqCDk.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/ZvUIVhZ0Tq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/ZvUIVhZ0Tq.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/eCMIYOrmhM.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/eCMIYOrmhM.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/eqvqJLSgNt.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/eqvqJLSgNt.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/fNGpTc98HV.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/fNGpTc98HV.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/gOCS92pR6N.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/gOCS92pR6N.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/h5DE7WWNVZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/h5DE7WWNVZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/iZF9DuDqS4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/iZF9DuDqS4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/jZxRes3tml.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/jZxRes3tml.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/mC8omC0oGh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/mC8omC0oGh.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/mUefl9vRDY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/mUefl9vRDY.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/q5akUgBzW7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/q5akUgBzW7.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/qO7jCfiuqY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/qO7jCfiuqY.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/rNY0qyjWJz.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/rNY0qyjWJz.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/sfc3wXgHuD.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/sfc3wXgHuD.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/tvyMAyAmHN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/tvyMAyAmHN.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/uWhzk4japH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/uWhzk4japH.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/v3e1ZC6VRK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/v3e1ZC6VRK.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/w62iXy02QC.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/w62iXy02QC.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/yE4PKEmLLH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/yE4PKEmLLH.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/0Zt9V0JhWk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/0Zt9V0JhWk.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/2Zxz6JMYpm.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/2Zxz6JMYpm.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/4JNS7O0k9y.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/4JNS7O0k9y.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/4gi5k2cnhO.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/4gi5k2cnhO.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/5Jdwip14W4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/5Jdwip14W4.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/5d92k1xTpK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/5d92k1xTpK.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/8riru9hqK8.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/8riru9hqK8.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/HGI0kSajp0.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/HGI0kSajp0.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/Jy4lCC5HMZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/Jy4lCC5HMZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/KElo1QPpSg.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/KElo1QPpSg.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/KkXuTfNkW1.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/KkXuTfNkW1.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/Mygm5N0qEU.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/Mygm5N0qEU.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/OG7GkP6ZVr.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/OG7GkP6ZVr.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/P4TTCc0Yf7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/P4TTCc0Yf7.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/PEAxX22zUN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/PEAxX22zUN.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/SJIzsboRZf.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/SJIzsboRZf.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/UGoNa5iv8W.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/UGoNa5iv8W.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/VczYkuMFxN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/VczYkuMFxN.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/Vui3UGMZoh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/Vui3UGMZoh.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/YAIRrkTGEq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/YAIRrkTGEq.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/YxUmKOqCDk.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/YxUmKOqCDk.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/ZvUIVhZ0Tq.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/ZvUIVhZ0Tq.verified.txt
@@ -187,7 +187,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/eCMIYOrmhM.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/eCMIYOrmhM.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/eqvqJLSgNt.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/eqvqJLSgNt.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/fNGpTc98HV.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/fNGpTc98HV.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/gOCS92pR6N.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/gOCS92pR6N.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/h5DE7WWNVZ.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/h5DE7WWNVZ.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/iZF9DuDqS4.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/iZF9DuDqS4.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/jZxRes3tml.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/jZxRes3tml.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/mC8omC0oGh.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/mC8omC0oGh.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/mUefl9vRDY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/mUefl9vRDY.verified.txt
@@ -230,7 +230,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/q5akUgBzW7.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/q5akUgBzW7.verified.txt
@@ -174,7 +174,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/qO7jCfiuqY.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/qO7jCfiuqY.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_record_classConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/rNY0qyjWJz.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/rNY0qyjWJz.verified.txt
@@ -217,7 +217,8 @@ public System.String Value
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_sealed_partial_classConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/sfc3wXgHuD.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/sfc3wXgHuD.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/tvyMAyAmHN.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/tvyMAyAmHN.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_classConversions_NewtonsoftJson___Conversions_SystemTextJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/uWhzk4japH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/uWhzk4japH.verified.txt
@@ -160,7 +160,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_readonly_partial_record_structConversions_NewtonsoftJsonstring_customized.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/v3e1ZC6VRK.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/v3e1ZC6VRK.verified.txt
@@ -173,7 +173,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_record_structConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/w62iXy02QC.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/w62iXy02QC.verified.txt
@@ -184,7 +184,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJson___Conversions_SystemTextJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/yE4PKEmLLH.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/yE4PKEmLLH.verified.txt
@@ -171,7 +171,8 @@ namespace Whatever
 
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
-                return stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(serializer.Deserialize<global::System.String>(reader));
+                var result = serializer.Deserialize<global::System.String>(reader);
+                return result != null ? stj_number_as_string_public_partial_recordConversions_NewtonsoftJsonstring.Deserialize(result) : null;
             }
         }
 

--- a/tests/Vogen.Tests/TemplatesTests.cs
+++ b/tests/Vogen.Tests/TemplatesTests.cs
@@ -8,22 +8,22 @@ namespace Vogen.Tests;
 
 public class TemplatesTests
 {
+    [Theory]
+    [ClassData(typeof(SpecificTypes))]
+    public void CanGetItemFromTypeName(Type type, string tech) => Templates.TryGetForSpecificType(type, tech).Should().NotBeNull();
 
+    [Theory]
+    [ClassData(typeof(AnyTypes))]
+#pragma warning disable xUnit1026
+    public void CanGetItemForAnyType(Type unused, string tech) => Templates.GetForAnyType(tech).Should().NotBeNull();
+#pragma warning restore xUnit1026
+    
     private class Types : IEnumerable<object[]>
     {
-        private readonly Type[] _types = new[]
-        {
-            typeof(bool), typeof(byte), typeof(char), typeof(DateOnly), typeof(DateTime), typeof(DateTimeOffset), typeof(decimal),
-            typeof(double), typeof(float), typeof(Guid), typeof(System.Int32), typeof(long), typeof(short), typeof(string),
-            typeof(TimeOnly)
-        };
+        private readonly string[] _technologies;
 
-        private readonly string[] _technologies = new[]
-        {
-            "DapperTypeHandler", "EfCoreValueConverter", "LinqToDbValueConverter", "NewtonsoftJsonConverter", "SystemTextJsonConverter",
-            "TypeConverter"
-        };
-        
+        public Types(string[] technologies) => _technologies = technologies;
+
         public IEnumerator<object[]> GetEnumerator()
         {
             foreach (var eachType in _types)
@@ -34,17 +34,40 @@ public class TemplatesTests
                 }
             }
         }
+        
+        private static readonly Type[] _types = 
+        {
+            typeof(bool), typeof(byte), typeof(char), typeof(DateOnly), typeof(DateTime), typeof(DateTimeOffset), typeof(decimal),
+            typeof(double), typeof(float), typeof(Guid), typeof(System.Int32), typeof(long), typeof(short), typeof(string),
+            typeof(TimeOnly)
+        };
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
-    
-    [Theory]
-    [ClassData(typeof(Types))]
-    public void CanGetItemFromTypeName(Type type, string tech) => Templates.TryGetForSpecificType(type, tech).Should().NotBeNull();
 
-    [Theory]
-    [ClassData(typeof(Types))]
-#pragma warning disable xUnit1026
-    public void CanGetItemForAnyType(Type unused, string tech) => Templates.GetForAnyType(tech).Should().NotBeNull();
-#pragma warning restore xUnit1026
+    private class AnyTypes : Types
+    {
+        public AnyTypes() : base(_technologies)
+        {
+        }
+
+        private static readonly string[] _technologies = 
+        {
+            "DapperTypeHandler", "EfCoreValueConverter", "LinqToDbValueConverter", "NewtonsoftJsonConverterReferenceType", "NewtonsoftJsonConverterValueType", "SystemTextJsonConverter",
+            "TypeConverter"
+        };
+    }
+
+    private class SpecificTypes : Types
+    {
+        public SpecificTypes() : base(_technologies)
+        {
+        }
+
+        private static readonly string[] _technologies = 
+        {
+            "DapperTypeHandler", "EfCoreValueConverter", "LinqToDbValueConverter", "SystemTextJsonConverter",
+            "TypeConverter"
+        };
+    }
 }


### PR DESCRIPTION
This is an attempt at fixing the behavior of the Newtonsoft.Json converter when confronted with serializing nullable fields of ValueTypes of reference types.

Its still failing the Snapshot tests as I have no clue how to update all the snapshots and haven't been able to find any documentation regarding this.

Its also failing some other tests for reasons I don't really understand as they are also failing in a clean pull of the main branch ( for example all tests dealing with date time offset fail because they expect the offset to timezone to be 0:00 while my local timezone is +1:00 (these seem to be a bit brittle).

Other tests that fail are indeed Newtonsoft.Json tests, however those test failures are a bit weird as they fail in the _serialization step_ which now serializes some value objects to a null string. However I didn't touch that code at all and this result also seems to hold for a clean pull of the main branch. Its a bit weird, we'll see how the CI test runners handle this one.

I might add that I'm developing on Linux and the tooling around the project seems to mostly assume a Windows environment.

Also the tests are missing a test for non ValueType user types as ValueObject types.

Fixes #344 