### PR TITLE
Remove redundant verified includes

### DIFF
--- a/tests/SnapshotTests/SnapshotTests.csproj
+++ b/tests/SnapshotTests/SnapshotTests.csproj
@@ -63,17 +63,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="SnapshotTests\Snapshots\ValueObjectGeneratorTests.Validation_with_camelCased_validate_method.verified.txt">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <DependentUpon>%(ParentFile).cs</DependentUpon>
-    </None>
-    <None Update="SnapshotTests\Snapshots\ValueObjectGeneratorTests.Validation_with_PacalCased_validate_method.verified.txt">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <DependentUpon>%(ParentFile).cs</DependentUpon>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="InstanceFields\" />
   </ItemGroup>
 


### PR DESCRIPTION
These occur due to a bug in VS where it incorrectly duplicates dynamic includes when you copy/rename a test file.