### PR TITLE
fixed issue with VoFilter not matching the generic ValueObjectAttribute

### DIFF
--- a/src/Vogen/VoFilter.cs
+++ b/src/Vogen/VoFilter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -68,7 +69,7 @@ internal static class VoFilter
         }
 
         AttributeData? voAttribute =
-            attributes.SingleOrDefault(a => a.AttributeClass?.FullName() is "Vogen.ValueObjectAttribute");
+            attributes.SingleOrDefault(a => a.AttributeClass?.FullName()?.StartsWith("Vogen.ValueObjectAttribute", StringComparison.Ordinal) == true);
 
         return voAttribute is not null;
     }

--- a/src/Vogen/VoFilter.cs
+++ b/src/Vogen/VoFilter.cs
@@ -54,23 +54,6 @@ internal static class VoFilter
         return null;
     }
 
-    public static bool IsTarget(INamedTypeSymbol? voClass)
-    {
-        if (voClass == null)
-        {
-            return false;
-        }
-
-        ImmutableArray<AttributeData> attributes = voClass.GetAttributes();
-
-        if (attributes.Length == 0)
-        {
-            return false;
-        }
-
-        AttributeData? voAttribute =
-            attributes.SingleOrDefault(a => a.AttributeClass?.FullName()?.StartsWith("Vogen.ValueObjectAttribute", StringComparison.Ordinal) == true);
-
-        return voAttribute is not null;
-    }
+    public static bool IsTarget(INamedTypeSymbol? voClass) => 
+        voClass is not null && TryGetValueObjectAttributes(voClass).Any();
 }


### PR DESCRIPTION
This solves the bug reported in: https://github.com/SteveDunn/Vogen/issues/389
The issue was that the VoFilter didn't match the generic ValueObjectAttribute FullName.

I also created a test case based on an existing to verify that the issue is fixed