### PR TITLE
Use FormattableString.Invariant in culture dependent tests

### DIFF
--- a/tests/Vogen.Tests/InstanceGenerationTests.cs
+++ b/tests/Vogen.Tests/InstanceGenerationTests.cs
@@ -40,7 +40,7 @@ public class InstanceGenerationTests
 
             using var x = new AssertionScope();
             r.Success.Should().BeTrue();
-            r.Value.Should().Be($"{input}m");
+            r.Value.Should().Be(FormattableString.Invariant($"{input}m"));
         }
     }
 
@@ -62,7 +62,7 @@ public class InstanceGenerationTests
 
             using var x = new AssertionScope();
             r.Success.Should().BeTrue();
-            r.Value.Should().Be($"{input}d");
+            r.Value.Should().Be(FormattableString.Invariant($"{input}d"));
         }
     }
 
@@ -84,7 +84,7 @@ public class InstanceGenerationTests
 
             using var x = new AssertionScope();
             r.Success.Should().BeTrue();
-            r.Value.Should().Be($"{input}f");
+            r.Value.Should().Be(FormattableString.Invariant($"{input}f"));
         }
     }
 


### PR DESCRIPTION
When running locally I had a few test cases breaking as we use ',' as the decimal separator in Denmark.

I fixed the test cases by using FormattableString.Invariant() for the expected input