### PR TITLE
Use 'is not null' instead of '!= null' in Newtonsoft converter

### DIFF
--- a/src/Vogen/Templates/AnyOtherType/AnyOtherType_NewtonsoftJsonConverterReferenceType.cs
+++ b/src/Vogen/Templates/AnyOtherType/AnyOtherType_NewtonsoftJsonConverterReferenceType.cs
@@ -15,6 +15,6 @@
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
             {
                 var result = serializer.Deserialize<VOUNDERLYINGTYPE>(reader);
-                return result != null ? VOTYPE.Deserialize(result) : null;
+                return result is not null ? VOTYPE.Deserialize(result) : null;
             }
         }


### PR DESCRIPTION
Vogen does not follow best practices for null checks. Instead of using the "is" operator, it is using equality operators. This sometimes causes issues when a class has overloaded the equality operators.

Consider this code:

```
[ValueObject(typeof(String))]
public partial class LinuxAbsoluteFilename: IAbsoluteFilename
{
	public static Boolean operator ==(LinuxAbsoluteFilename? Left, IAbsoluteFilename? Right);
	public static Boolean operator !=(LinuxAbsoluteFilename? Left, IAbsoluteFilename? Right);
}

[ValueObject(typeof(LinuxAbsoluteFilename), conversions: Conversions.NewtonsoftJson)]
public sealed partial class AbsoluteContainerFilename
{
}
```

When using the Newtonsoft converter, the generated code by Vogen looks like:

```
var result = serializer.Deserialize<LinuxAbsoluteFilename>(reader);
return result != null ? AbsoluteContainerFilename.Deserialize(result) : null;
```

The problem with this generated code is that Vogen uses != instead of not null, and so the compiler is unable to determine which operator to call. If we look at the metadata for the class LinuxAbsoluteFilename, since Vogen also adds its own operators, we see:

`[DebuggerDisplay("Underlying type: System.String, Value = { _value }")]
[DebuggerTypeProxy(typeof(LinuxAbsoluteFilenameDebugView))]
[ExcludeFromCodeCoverage]
[GeneratedCode("Vogen", "3.0.0.0")]
[JsonConverter(typeof(LinuxAbsoluteFilenameSystemTextJsonConverter))]
[TypeConverter(typeof(LinuxAbsoluteFilenameTypeConverter))]
[ValueObject(typeof(String), Conversions.Default, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default)]
public class LinuxAbsoluteFilename: IAbsoluteFilename, IFilename, IEquatable<IAbsoluteFilename>, IEquatable<LinuxAbsoluteFilename>, IEquatable<String>, IComparable<LinuxAbsoluteFilename>, IComparable
{
	public static Boolean operator ==(LinuxAbsoluteFilename? Left, IAbsoluteFilename? Right);
	public static Boolean operator ==(LinuxAbsoluteFilename left, String right);
	public static Boolean operator ==(String left, LinuxAbsoluteFilename right);
	public static Boolean operator ==(LinuxAbsoluteFilename left, LinuxAbsoluteFilename right);
	public static Boolean operator !=(String left, LinuxAbsoluteFilename right);
	public static Boolean operator !=(LinuxAbsoluteFilename left, String right);
	public static Boolean operator !=(LinuxAbsoluteFilename left, LinuxAbsoluteFilename right);
	public static Boolean operator !=(LinuxAbsoluteFilename? Left, IAbsoluteFilename? Right);
}`

So the compiler has three overloads to choose from:

`	public static Boolean operator !=(LinuxAbsoluteFilename left, String right);
	public static Boolean operator !=(LinuxAbsoluteFilename left, LinuxAbsoluteFilename right);
	public static Boolean operator !=(LinuxAbsoluteFilename? Left, IAbsoluteFilename? Right);`

Since null is not strongly typed, the call is ambiguous. This can be prevented by using "is not null" instead.
But for now, this is causing a compile error for all such value objects. 

This PR solves at least this issue for a specific case of Newtonsoft. I am not familiar enough with the code to know if there are similar issues elsewhere, so I have only fixed this specific place.