### PR TITLE
Explicitly override System.Formats.Asn1 

### DIFF
--- a/tests/AnalyzerTests/AnalyzerTests.csproj
+++ b/tests/AnalyzerTests/AnalyzerTests.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Shared/Shared.csproj
+++ b/tests/Shared/Shared.csproj
@@ -10,6 +10,8 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>

--- a/tests/SnapshotTests/SnapshotTests.csproj
+++ b/tests/SnapshotTests/SnapshotTests.csproj
@@ -22,6 +22,8 @@
 </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
RunSnapshots.ps1 is currently blocked by a warning-as-error due to https://github.com/dotnet/announcements/issues/312. The package is transitively referenced and it doesn't seem the NuGets on the path will receive any updates any time soon, so explicitly overriding the version is the only thing that can be done.