### PR TITLE
Use invariant culture in unit test string comparison

### DIFF
--- a/tests/ConsumerTests/ParsingAndFormattingTests/TryFormatTests.cs
+++ b/tests/ConsumerTests/ParsingAndFormattingTests/TryFormatTests.cs
@@ -16,9 +16,9 @@ public class TryFormatTests
 
         MyDecimal d = MyDecimal.From(1.23m);
 
-        $"{d:0.000}".Should().Be("1.230");
+        FormattableString.Invariant($"{d:0.000}").Should().Be("1.230");
         d.ToString("0.00", new CultureInfo("fr")).Should().Be("1,23");
-        $"{d:0.000}".Should().Be("1.230");
+        FormattableString.Invariant($"{d:0.000}").Should().Be("1.230");
 
         Span<char> s2 = stackalloc char[8];
         MyDecimal.From(1.23m).TryFormat(s2, out written, "000.00", CultureInfo.InvariantCulture).Should().BeTrue();

--- a/tests/ConsumerTests/ToStringTests/BasicFunctionality.cs
+++ b/tests/ConsumerTests/ToStringTests/BasicFunctionality.cs
@@ -1,4 +1,5 @@
-﻿using Vogen.Tests.Types;
+﻿using System.Globalization;
+using Vogen.Tests.Types;
 
 namespace ConsumerTests.ToStringTests;
 
@@ -74,7 +75,8 @@ public class BasicFunctionality
         Age.From(100).ToString("x8").Should().Be("00000064");
         
         
-        Age.From((int)Math.Pow(2, 8)).ToString("E").Should().Be("2.560000E+002");
+        Age.From((int)Math.Pow(2, 8)).ToString("E", CultureInfo.InvariantCulture)
+            .Should().Be("2.560000E+002");
         
         Name.From("fred").ToString().Should().Be("fred");
         Name.From("barney").ToString().Should().Be("barney");


### PR DESCRIPTION
This PR removes culture dependency of two consumer unit tests.

