### PR TITLE
Fix invalid strong name on assembly

### DIFF
--- a/src/Vogen.SharedTypes/Vogen.SharedTypes.csproj
+++ b/src/Vogen.SharedTypes/Vogen.SharedTypes.csproj
@@ -6,7 +6,6 @@
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\strongname.snk</AssemblyOriginatorKeyFile>
-    <PublicSign>true</PublicSign>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DocumentationFile>bin\Debug\Vogen.SharedTypes.xml</DocumentationFile>


### PR DESCRIPTION
The issue here was that although you have the private key with which to sign, the build wasn't using it.

`PublicSign=true` tells the build to _not_ sign the assembly, but merely give it the strong name. This is fine for .NET but breaks in certain scenarios on .NET Framework.

Fixes #761