### PR TITLE
Allows instances to be static getter properties

### DIFF
--- a/samples/Vogen.Examples/TypicalScenarios/Instances.cs
+++ b/samples/Vogen.Examples/TypicalScenarios/Instances.cs
@@ -36,6 +36,17 @@ namespace Vogen.Examples.TypicalScenarios.Instances
             value >= AbsoluteZero.Value ? Validation.Ok : Validation.Invalid("Cannot be colder than absolute zero");
     }
 
+    [ValueObject<float>]
+    public readonly partial struct Fahrenheit
+    {
+        public static readonly Fahrenheit Freezing = new(32);
+        public static Fahrenheit Boiling { get; } = new(212);
+        public static Fahrenheit AbsoluteZero { get; } = new(-459.67f);
+
+        private static Validation Validate(float value) =>
+            value >= AbsoluteZero.Value ? Validation.Ok : Validation.Invalid("Cannot be colder than absolute zero");
+    }
+
     /*
      * Instances are the only way to avoid validation, so we can create instances
      * that nobody else can. This is useful for creating special instances

--- a/tests/AnalyzerTests/DoNotUseNewAnalyzerTests.cs
+++ b/tests/AnalyzerTests/DoNotUseNewAnalyzerTests.cs
@@ -154,6 +154,54 @@ namespace AnalyzerTests
 
         [Theory]
         [ClassData(typeof(Types))]
+        public async Task Allow_as_public_static_getter_property_in_a_VO(string type)
+        {
+            var userSource = $$"""
+
+                           using Vogen;
+                           namespace Whatever
+                           {
+                               [ValueObject]
+                               public {{type}} MyVo {
+                                    public static MyVo Unspecified { get; } = new MyVo(-1);
+                               }
+                           }
+
+                           """;
+            string[] sources = await CombineUserAndGeneratedSource(userSource);
+
+            await Run(sources, Enumerable.Empty<DiagnosticResult>());
+        }
+
+        [Theory]
+        [ClassData(typeof(Types))]
+        public async Task Disallow_as_setter_property_in_a_VO(string type)
+        {
+            var userSource = $$"""
+
+                           using Vogen;
+                           namespace Whatever
+                           {
+                               [ValueObject]
+                               public {{type}} MyVo {
+                                    public static MyVo Unspecified { get; set; } = {|#0:new MyVo()|};
+                                    public static MyVo Unspecified2 { get; set; } = {|#1:new()|};
+                                    private static MyVo Unspecified3 { get; set; } = {|#2:new MyVo()|};
+                                    private static MyVo Unspecified4 { get; set; } = {|#3:new()|};
+                               }
+                           }
+
+                           """;
+
+            string[] sources = await CombineUserAndGeneratedSource(userSource);
+
+            await Run(
+                sources,
+                WithDiagnostics("VOG010", DiagnosticSeverity.Error, "MyVo", 0, 1, 2, 3));
+        }
+
+        [Theory]
+        [ClassData(typeof(Types))]
         public async Task Disallow_new_from_local_function(string type)
         {
             var source = $$"""

--- a/tests/AnalyzerTests/DoNotUseNewAnalyzerTests.cs
+++ b/tests/AnalyzerTests/DoNotUseNewAnalyzerTests.cs
@@ -130,6 +130,30 @@ namespace AnalyzerTests
 
         [Theory]
         [ClassData(typeof(Types))]
+        public async Task Disallow_new_from_property(string type)
+        {
+            var source = $$"""
+
+                           using Vogen;
+                           namespace Whatever;
+
+                           [ValueObject]
+                           public {{type}} MyVo { }
+
+                           public class Test {
+                               public MyVo Get { get; } = {|#0:new MyVo()|};
+                               public MyVo Get2 { get; } = {|#1:new()|};
+                           }
+
+                           """;
+
+            await Run(
+                source,
+                WithDiagnostics("VOG010", DiagnosticSeverity.Error, "MyVo", 0, 1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Types))]
         public async Task Disallow_new_from_local_function(string type)
         {
             var source = $$"""


### PR DESCRIPTION
Fixes #787

Relaxes VOG010 slightly so that instances can also be static properties without a setter (init is already disallowed on static properties).

This supports design guidelines that prefer to use properties over fields for public members.