### PR TITLE
Allow NewTonSoft to Serialize Uninitialized Value

### DIFF
--- a/src/Vogen.Pack/Vogen.Pack.csproj
+++ b/src/Vogen.Pack/Vogen.Pack.csproj
@@ -8,8 +8,8 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
 
     <!-- Version and PackageVersion are handled in Directory.Build.targets -->
-    <PackageId>Vogen</PackageId>
-    <PackageProjectUrl>https://github.com/SteveDunn/Vogen</PackageProjectUrl>
+    <PackageId>GreatUtilities.Vogen</PackageId>
+    <PackageProjectUrl>https://github.com/ziongh/Vogen</PackageProjectUrl>
     <PackageOutputPath>$(MSBuildThisFileDirectory)\..\artifacts</PackageOutputPath>
     <PackageTags>vogen;stringlytyped;primitive;obsession;valuetype;valuetypes;valueobj;valueobjects;ddd</PackageTags>
     <PackageIcon>package_logo_128x128.png</PackageIcon>

--- a/src/Vogen.SharedTypes/Customizations.cs
+++ b/src/Vogen.SharedTypes/Customizations.cs
@@ -36,5 +36,10 @@ public enum Customizations
     /// <summary>
     /// Generate ToDump for LinqPad
     /// </summary>
-    GenerateLinqPadToDump = 1 << 2
+    GenerateLinqPadToDump = 1 << 2,
+    
+    /// <summary>
+    /// Generate ToDump for LinqPad
+    /// </summary>
+    AllowSerializingUninitializedNewtonSoft = 1 << 3
 }


### PR DESCRIPTION
Sometimes we need to serialize an object that may not have it's value initialized yet. (ex.: Auditing into Json all changes to an entity before saving to the Database; Auditing the API request the user sent of a Create that may have a non initialized value; etc.)

I've made something simple using only Newtonsoft, but I can expand, if the ideia is approved.