### PR TITLE
avoid a NullReferenceException in the Orleans Serializers when using a nullable method parameter on a grain call

### DIFF
--- a/src/Vogen/GenerateCodeForOrleansSerializers.cs
+++ b/src/Vogen/GenerateCodeForOrleansSerializers.cs
@@ -61,7 +61,7 @@ internal class GenerateCodeForOrleansSerializers
                       where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
                   {
                       var baseCodec = writer.Session.CodecProvider.GetCodec<{{underlyingTypeName}}>();
-                      baseCodec.WriteField(ref writer, fieldIdDelta, typeof({{underlyingTypeName}}), value.Value);
+                      baseCodec.WriteField(ref writer, fieldIdDelta, typeof({{underlyingTypeName}}), value?.Value);
                   }
               
                   public {{item.VoTypeName}} ReadValue<TInput>(ref global::Orleans.Serialization.Buffers.Reader<TInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
@@ -80,6 +80,7 @@ internal class GenerateCodeForOrleansSerializers
               {
                   public {{item.VoTypeName}} DeepCopy({{item.VoTypeName}} input, global::Orleans.Serialization.Cloning.CopyContext context)
                   {
+                      if (input is null) return null;
                       return {{item.VoTypeName}}.From(input.Value);
                   }
               }


### PR DESCRIPTION
This patch fixes #811 

Sorry I could not find any unit tests for this feature to update  - however https://github.com/stocksr/Vogen/commit/71af16957a07638f3e011ffdb555b26b79dd3081 is a way to demonstrate the bug / prove the fix did you want me to include that in the PR?