### PR TITLE
fix Conversions setting to allow a local overide to specify Conversion.Default when the Global value is set to somthing else

### DIFF
--- a/src/Vogen.SharedTypes/Conversions.cs
+++ b/src/Vogen.SharedTypes/Conversions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace Vogen;
 
@@ -8,6 +9,11 @@ namespace Vogen;
 [Flags]
 public enum Conversions
 {
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    Unspecified = -1,
+
+
     // Used with HasFlag, so needs to be 1, 2, 4 etc
 
     /// <summary>

--- a/src/Vogen.SharedTypes/ValueObjectAttribute.cs
+++ b/src/Vogen.SharedTypes/ValueObjectAttribute.cs
@@ -54,7 +54,7 @@ namespace Vogen
         /// </example>
         /// </param>
         public ValueObjectAttribute(
-            Conversions conversions = Conversions.Default,
+            Conversions conversions = Conversions.Unspecified,
             Type? throws = null!,
             Customizations customizations = Customizations.None,
             DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,
@@ -131,7 +131,7 @@ namespace Vogen
         /// </param>
         public ValueObjectAttribute(
             Type? underlyingType = null!,
-            Conversions conversions = Conversions.Default,
+            Conversions conversions = Conversions.Unspecified,
             Type? throws = null!,
             Customizations customizations = Customizations.None,
             DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,

--- a/src/Vogen.SharedTypes/VogenDefaultsAttribute.cs
+++ b/src/Vogen.SharedTypes/VogenDefaultsAttribute.cs
@@ -54,7 +54,7 @@ public class VogenDefaultsAttribute : Attribute
     /// <param name="explicitlySpecifyTypeInValueObject">Every ValueObject attribute must explicitly specify the type of the primitive.</param>
     public VogenDefaultsAttribute(
         Type? underlyingType = null,
-        Conversions conversions = Conversions.Default,
+        Conversions conversions = Conversions.Unspecified,
         Type? throws = null,
         Customizations customizations = Customizations.None,
         DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,

--- a/src/Vogen/BuildConfigurationFromAttributes.cs
+++ b/src/Vogen/BuildConfigurationFromAttributes.cs
@@ -42,7 +42,7 @@ internal class BuildConfigurationFromAttributes
         _matchingAttribute = att;
         _invalidExceptionType = null;
         _underlyingType = null;
-        _conversions = Conversions.Default;
+        _conversions = Conversions.Unspecified;
         _customizations = Customizations.None;
         _deserializationStrictness = DeserializationStrictness.Default;
         _debuggerAttributes = DebuggerAttributeGeneration.Default;

--- a/src/Vogen/CombineConfigurations.cs
+++ b/src/Vogen/CombineConfigurations.cs
@@ -23,9 +23,9 @@ public static class CombineConfigurations
     {
         var conversions = (localValues.Conversions, globalValues?.Conversions) switch
         {
-            (Conversions.Default, null) => VogenConfiguration.DefaultInstance.Conversions,
-            (Conversions.Default, Conversions.Default) => VogenConfiguration.DefaultInstance.Conversions,
-            (Conversions.Default, var globalDefault) => globalDefault.Value,
+            (Conversions.Unspecified, null) => VogenConfiguration.DefaultInstance.Conversions,
+            (Conversions.Unspecified, Conversions.Unspecified) => VogenConfiguration.DefaultInstance.Conversions,
+            (Conversions.Unspecified, var globalDefault) => globalDefault.Value,
             (var specificValue, _) => specificValue
         };
 

--- a/src/Vogen/EnumExtensions.cs
+++ b/src/Vogen/EnumExtensions.cs
@@ -9,8 +9,8 @@ internal static class EnumExtensions
     private static readonly int _maxCustomization = Enum.GetValues(typeof(Customizations)).Cast<int>().Max() * 2;
     private static readonly int _maxDeserializationStrictness = Enum.GetValues(typeof(DeserializationStrictness)).Cast<int>().Max() * 2;
 
-    public static bool IsValidFlags(this Conversions value) => (int) value >= 0 && (int) value < _maxConversion;
     
+    public static bool IsValidFlags(this Conversions value) => (int) value >= -1 && (int) value < _maxConversion;
     public static bool IsValidFlags(this Customizations value) => (int) value >= 0 && (int) value < _maxCustomization;
     
     public static bool IsValidFlags(this DeserializationStrictness value) => (int) value >= 0 && (int) value < _maxDeserializationStrictness;

--- a/tests/Vogen.Tests/ConfigurationTests/VogenConfigurationTests.cs
+++ b/tests/Vogen.Tests/ConfigurationTests/VogenConfigurationTests.cs
@@ -172,7 +172,7 @@ public class VogenConfigurationTests
         }
 
         [Fact]
-        public void default_is_correct()
+        public void Default_is_correct()
         {
             var result = CombineConfigurations.CombineAndResolveAnythingUnspecified(
                 ConfigWithOmitConversionsAs(Conversions.Default),
@@ -182,22 +182,54 @@ public class VogenConfigurationTests
         }
 
         [Fact]
-        public void default_is_overridable_locally()
+        public void Unspecified_is_Default()
         {
             var result = CombineConfigurations.CombineAndResolveAnythingUnspecified(
-                ConfigWithOmitConversionsAs(Conversions.Default),
+                ConfigWithOmitConversionsAs(Conversions.Unspecified),
+                ConfigWithOmitConversionsAs(Conversions.Unspecified));
+
+            result.Conversions.Should().Be(Conversions.Default);
+        }
+
+        [Fact]
+        public void Unspecified_is_overridable_locally()
+        {
+            var result = CombineConfigurations.CombineAndResolveAnythingUnspecified(
+                ConfigWithOmitConversionsAs(Conversions.Unspecified),
                 ConfigWithOmitConversionsAs(Conversions.NewtonsoftJson));
 
             result.Conversions.Should().Be(Conversions.NewtonsoftJson);
         }
         [Fact]
-        public void default_is_overridable_globally()
+        public void Unspecified_is_overridable_globally()
         {
             var result = CombineConfigurations.CombineAndResolveAnythingUnspecified(
                 ConfigWithOmitConversionsAs(Conversions.NewtonsoftJson),
-                ConfigWithOmitConversionsAs(Conversions.Default));
+                ConfigWithOmitConversionsAs(Conversions.Unspecified));
 
             result.Conversions.Should().Be(Conversions.NewtonsoftJson);
+        }
+
+        [Fact]
+        public void Default_is_combinable_with_other_enum_members()
+        {
+            var result = CombineConfigurations.CombineAndResolveAnythingUnspecified(
+                ConfigWithOmitConversionsAs(Conversions.Default | Conversions.NewtonsoftJson),
+                ConfigWithOmitConversionsAs(Conversions.Unspecified));
+
+            result.Conversions.Should().Be(Conversions.NewtonsoftJson | Conversions.SystemTextJson | Conversions.TypeConverter);
+        }
+
+        [Fact]
+        public void Unspecified_when_combined_with_other_enum_members_forces_the_value_to_unspecified()
+        {
+            // This is a bit strange - but because of the -1 value of Unspecified - it works this way
+            // And I think that it is ok for this to be the behaviour
+            var result = CombineConfigurations.CombineAndResolveAnythingUnspecified(
+                ConfigWithOmitConversionsAs(Conversions.Unspecified | Conversions.NewtonsoftJson),
+                ConfigWithOmitConversionsAs(Conversions.Unspecified | Conversions.NewtonsoftJson));
+
+            result.Conversions.Should().Be(Conversions.Default);
         }
 
         private static VogenConfiguration ConfigWithOmitConversionsAs(Conversions conversions) =>


### PR DESCRIPTION
Fixes #810 

Adds a new "Unspecifed" member to the Conversions Enum and uses that rather than Default
Adds unit tests for the new behavour and the previously broken behavour.

I have kept the "Conversions.Default" member for backwards compatibility - as any change to that causes a huge chunk of test fails. However I think it could be removed in the next major version.