### PR TITLE
Add PolyType support for efficient serialization integration

### DIFF
--- a/src/Vogen/Generators/ClassGenerator.cs
+++ b/src/Vogen/Generators/ClassGenerator.cs
@@ -31,6 +31,7 @@ public class ClassGenerator : IGenerateValueObjectSourceCode
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""{Util.GenerateYourAssemblyName()}"", ""{Util.GenerateYourAssemblyVersion()}"")]
     {Util.GenerateAnyConversionAttributes(tds, item)}
     {DebugGeneration.GenerateDebugAttributes(item, wrapperName, itemUnderlyingType)}
+    {Util.GeneratePolyTypeAttributeIfAvailable(parameters.VogenKnownSymbols)}
     {Util.GenerateModifiersFor(tds)} class {wrapperName} : 
         global::System.IEquatable<{wrapperName}>
         {GenerateCodeForEqualsMethodsAndOperators.GenerateInterfaceDefinitionsIfNeeded(", ", item)}
@@ -151,6 +152,8 @@ public class ClassGenerator : IGenerateValueObjectSourceCode
         {Util.GenerateDebuggerProxyForClasses(tds, item)}
 
         {Util.GenerateThrowHelper(item)}
+
+        {Util.GeneratePolyTypeMarshalerIfAvailable(parameters.VogenKnownSymbols, item)}
     }}
 
 {GenerateEfCoreExtensions.GenerateInnerIfNeeded(item)}

--- a/src/Vogen/Generators/RecordClassGenerator.cs
+++ b/src/Vogen/Generators/RecordClassGenerator.cs
@@ -30,6 +30,7 @@ public class RecordClassGenerator : IGenerateValueObjectSourceCode
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""{Util.GenerateYourAssemblyName()}"", ""{Util.GenerateYourAssemblyVersion()}"")]
     {Util.GenerateAnyConversionAttributes(tds, item)}
     {DebugGeneration.GenerateDebugAttributes(item, wrapperName, itemUnderlyingType)}
+    {Util.GeneratePolyTypeAttributeIfAvailable(parameters.VogenKnownSymbols)}
     {Util.GenerateModifiersFor(tds)} record class {wrapperName} : 
         global::System.IEquatable<{wrapperName}>
         {GenerateCodeForEqualsMethodsAndOperators.GenerateInterfaceDefinitionsIfNeeded(", ", item)}
@@ -158,6 +159,8 @@ public class RecordClassGenerator : IGenerateValueObjectSourceCode
         {Util.GenerateDebuggerProxyForClasses(tds, item)}
 
         {Util.GenerateThrowHelper(item)}
+
+        {Util.GeneratePolyTypeMarshalerIfAvailable(parameters.VogenKnownSymbols, item)}
    }}
 
 {GenerateEfCoreExtensions.GenerateInnerIfNeeded(item)}

--- a/src/Vogen/Generators/RecordStructGenerator.cs
+++ b/src/Vogen/Generators/RecordStructGenerator.cs
@@ -30,6 +30,7 @@ public class RecordStructGenerator : IGenerateValueObjectSourceCode
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""{Util.GenerateYourAssemblyName()}"", ""{Util.GenerateYourAssemblyVersion()}"")]
     {Util.GenerateAnyConversionAttributes(tds, item)}
     {DebugGeneration.GenerateDebugAttributes(item, wrapperName, itemUnderlyingType)}
+    {Util.GeneratePolyTypeAttributeIfAvailable(parameters.VogenKnownSymbols)}
     { Util.GenerateModifiersFor(tds)} record struct {wrapperName} : 
         global::System.IEquatable<{wrapperName}>
         {GenerateCodeForEqualsMethodsAndOperators.GenerateInterfaceDefinitionsIfNeeded(", ", item)}
@@ -148,6 +149,8 @@ public class RecordStructGenerator : IGenerateValueObjectSourceCode
         {Util.GenerateDebuggerProxyForStructs(item)}
 
         {Util.GenerateThrowHelper(item)}
+
+        {Util.GeneratePolyTypeMarshalerIfAvailable(parameters.VogenKnownSymbols, item)}
 }}
 
 {GenerateEfCoreExtensions.GenerateInnerIfNeeded(item)}

--- a/src/Vogen/Generators/StructGenerator.cs
+++ b/src/Vogen/Generators/StructGenerator.cs
@@ -30,6 +30,7 @@ public class StructGenerator : IGenerateValueObjectSourceCode
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""{Util.GenerateYourAssemblyName()}"", ""{Util.GenerateYourAssemblyVersion()}"")]
     {Util.GenerateAnyConversionAttributes(tds, item)}
     {DebugGeneration.GenerateDebugAttributes(item, wrapperName, itemUnderlyingType)}
+    {Util.GeneratePolyTypeAttributeIfAvailable(parameters.VogenKnownSymbols)}
 // ReSharper disable once UnusedType.Global
     {Util.GenerateModifiersFor(tds)} struct {wrapperName} : 
         global::System.IEquatable<{wrapperName}>
@@ -142,6 +143,8 @@ public class StructGenerator : IGenerateValueObjectSourceCode
         {Util.GenerateDebuggerProxyForStructs(item)}
 
         {Util.GenerateThrowHelper(item)}
+
+        {Util.GeneratePolyTypeMarshalerIfAvailable(parameters.VogenKnownSymbols, item)}
 }}
 
 {GenerateEfCoreExtensions.GenerateInnerIfNeeded(item)}

--- a/src/Vogen/Util.cs
+++ b/src/Vogen/Util.cs
@@ -456,6 +456,41 @@ internal static class Util
 
         return filename;
     }
+
+    /// <summary>
+    /// Generates PolyType attribute if PolyType.TypeShapeAttribute is available in the compilation
+    /// </summary>
+    public static string GeneratePolyTypeAttributeIfAvailable(VogenKnownSymbols knownSymbols)
+    {
+        if (knownSymbols.TypeShapeAttribute is null)
+        {
+            return string.Empty;
+        }
+
+        return @"    [global::PolyType.TypeShapeAttribute(Marshaler = typeof(PolyTypeMarshaler), Kind = global::PolyType.TypeShapeKind.None)]";
+    }
+
+    /// <summary>
+    /// Generates PolyType marshaler class if PolyType.TypeShapeAttribute is available in the compilation
+    /// </summary>
+    public static string GeneratePolyTypeMarshalerIfAvailable(VogenKnownSymbols knownSymbols, VoWorkItem item)
+    {
+        if (knownSymbols.TypeShapeAttribute is null)
+        {
+            return string.Empty;
+        }
+
+        var typeName = item.VoTypeName;
+        var underlyingType = item.UnderlyingTypeFullName;
+
+        return $@"
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public class PolyTypeMarshaler : global::PolyType.IMarshaler<{typeName}, {underlyingType}>
+        {{
+            {underlyingType} global::PolyType.IMarshaler<{typeName}, {underlyingType}>.Marshal({typeName} value) => value.Value;
+            {typeName} global::PolyType.IMarshaler<{typeName}, {underlyingType}>.Unmarshal({underlyingType} value) => From(value);
+        }}";
+    }
 }
 
 public static class DebugGeneration

--- a/src/Vogen/VogenKnownSymbols.cs
+++ b/src/Vogen/VogenKnownSymbols.cs
@@ -19,4 +19,7 @@ public class VogenKnownSymbols(Compilation compilation) : KnownSymbols(compilati
 
     public INamedTypeSymbol? OpenApiOptions => GetOrResolveType("Microsoft.AspNetCore.OpenApi.OpenApiOptions", ref _OpenApiOptions);
     private Option<INamedTypeSymbol?> _OpenApiOptions;
+
+    public INamedTypeSymbol? TypeShapeAttribute => GetOrResolveType("PolyType.TypeShapeAttribute", ref _TypeShapeAttribute);
+    private Option<INamedTypeSymbol?> _TypeShapeAttribute;
 }

--- a/tests/SnapshotTests/PolyType/PolyTypeTests.cs
+++ b/tests/SnapshotTests/PolyType/PolyTypeTests.cs
@@ -1,0 +1,67 @@
+using System.Threading.Tasks;
+using Shared;
+using Vogen;
+
+namespace SnapshotTests.PolyType;
+
+public class PolyTypeTests
+{
+    [Fact]
+    public async Task PolyType_support_is_not_generated_without_PolyType_reference()
+    {
+        var source =
+            """
+            using System;
+            using Vogen;
+            
+            namespace Whatever;
+            
+            [ValueObject<int>]
+            public partial struct MyId;
+            """;
+
+        await new SnapshotRunner<ValueObjectGenerator>()
+            .WithSource(source)
+            .RunOn(TargetFramework.Net8_0);
+    }
+
+    [Fact]
+    public async Task PolyType_support_is_generated_with_PolyType_reference()
+    {
+        var source =
+            """
+            using System;
+            using Vogen;
+            
+            namespace Whatever;
+            
+            // Simulate having PolyType available by defining the attribute
+            namespace PolyType
+            {
+                public class TypeShapeAttribute : System.Attribute
+                {
+                    public System.Type? Marshaler { get; set; }
+                    public TypeShapeKind Kind { get; set; }
+                }
+                
+                public enum TypeShapeKind
+                {
+                    None
+                }
+                
+                public interface IMarshaler<T, TUnderlying>
+                {
+                    TUnderlying Marshal(T value);
+                    T Unmarshal(TUnderlying value);
+                }
+            }
+            
+            [ValueObject<int>]
+            public partial struct MyId;
+            """;
+
+        await new SnapshotRunner<ValueObjectGenerator>()
+            .WithSource(source)
+            .RunOn(TargetFramework.Net8_0);
+    }
+}


### PR DESCRIPTION
This PR implements support for PolyType integration as requested in issue #834. The implementation conditionally emits additional code when `PolyType.TypeShapeAttribute` is available in the compilation, enabling seamless integration between Vogen value objects and PolyType-based serialization libraries like Nerdbank.MessagePack.

## Problem Statement

PolyType is a high-performance type modeling library that uses source generation to expose type graphs at runtime. However, PolyType's source generator cannot see code emitted by Vogen's source generator, creating a compatibility issue. This forces users to either:
- Use separate assemblies for data models and serialization (suboptimal)
- Accept inefficient serialized schemas with unnecessary wrapper layers

## Solution

When `PolyType.TypeShapeAttribute` is detected in the compilation, Vogen now automatically generates:

1. **TypeShape attribute** on the partial value object declaration
2. **PolyTypeMarshaler nested class** that implements `IMarshaler<T, TUnderlying>`

This enables PolyType to efficiently serialize/deserialize the underlying primitive value directly, bypassing the wrapper type and producing optimal schemas.

## Example

For a value object like:
```csharp
[ValueObject<int>]
public partial struct CustomerId { }
```

When PolyType is available, Vogen now generates:
```csharp
[global::PolyType.TypeShapeAttribute(Marshaler = typeof(PolyTypeMarshaler), Kind = global::PolyType.TypeShapeKind.None)]
public partial struct CustomerId
{
    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
    public class PolyTypeMarshaler : global::PolyType.IMarshaler<CustomerId, int>
    {
        int global::PolyType.IMarshaler<CustomerId, int>.Marshal(CustomerId value) => value.Value;
        CustomerId global::PolyType.IMarshaler<CustomerId, int>.Unmarshal(int value) => From(value);
    }
}
```

## Implementation Details

- **Conditional Generation**: Code only appears when `PolyType.TypeShapeAttribute` is found in the compilation
- **Zero Configuration**: No user flags or attributes required - automatically detects PolyType availability
- **Universal Support**: Works with all Vogen type declarations (class, struct, record class, record struct)
- **Type Safety**: Uses proper `global::` prefixes and follows existing Vogen patterns
- **Format Agnostic**: Works with any PolyType-based serialization library, not just MessagePack

## Benefits

- Enables high-performance serialization with PolyType without requiring separate assemblies
- Produces optimal serialized schemas by marshaling the underlying primitive directly
- Supports all current and future PolyType use cases
- Maintains full backward compatibility - no breaking changes

This resolves the core incompatibility between PolyType and Vogen source generators, enabling developers to use both libraries together seamlessly for efficient, type-safe serialization.

<!-- START COPILOT CODING AGENT SUFFIX -->



<!-- START COPILOT CODING AGENT TIPS -->
---
