### PR TITLE
Add .FromNullable

### DIFF
--- a/src/Vogen/Generators/ClassGenerator.cs
+++ b/src/Vogen/Generators/ClassGenerator.cs
@@ -101,6 +101,18 @@ public class ClassGenerator : IGenerateValueObjectSourceCode
             return new {wrapperName}(value);
         }}
 
+        /// <summary>
+        /// Builds a nullable instance from the provided underlying type.
+        /// </summary>
+        /// <param name=""value"">The underlying type.</param>
+        /// <returns>An instance of this type.</returns>
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        {Util.GenerateMethodModifiers(Accessibility.Public, ["static"], item.UserProvidedPartials.PartialFrom)} {wrapperName}? FromNullable({itemUnderlyingType}? value)
+        {{
+            {Util.GenerateNullCheckAndReturnNullIfNeeded(item)}
+            {Util.GenerateFrom(itemUnderlyingType)}
+        }}
+
         {GenerateCodeForTryFrom.GenerateForAClass(item, wrapperName, itemUnderlyingType)}
 
         {Util.GenerateIsInitializedMethod(false, item)}

--- a/src/Vogen/Generators/RecordClassGenerator.cs
+++ b/src/Vogen/Generators/RecordClassGenerator.cs
@@ -111,6 +111,18 @@ public class RecordClassGenerator : IGenerateValueObjectSourceCode
             return new {wrapperName}(value);
         }}
 
+        /// <summary>
+        /// Builds a nullable instance from the provided underlying type.
+        /// </summary>
+        /// <param name=""value"">The underlying type.</param>
+        /// <returns>An instance of this type.</returns>
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        {Util.GenerateMethodModifiers(Accessibility.Public, ["static"], item.UserProvidedPartials.PartialFrom)} {wrapperName}? FromNullable({itemUnderlyingType}? value)
+        {{
+            {Util.GenerateNullCheckAndReturnNullIfNeeded(item)}
+            {Util.GenerateFrom(itemUnderlyingType)}
+        }}
+
         {GenerateCodeForTryFrom.GenerateForAStruct(item, wrapperName, itemUnderlyingType)}
 
 {Util.GenerateIsInitializedMethod(@readonly: false, item)}

--- a/src/Vogen/Generators/RecordStructGenerator.cs
+++ b/src/Vogen/Generators/RecordStructGenerator.cs
@@ -99,6 +99,18 @@ public class RecordStructGenerator : IGenerateValueObjectSourceCode
             return new {wrapperName}(value);
         }}
 
+        /// <summary>
+        /// Builds a nullable instance from the provided underlying type.
+        /// </summary>
+        /// <param name=""value"">The underlying type.</param>
+        /// <returns>An instance of this type.</returns>
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        {Util.GenerateMethodModifiers(Accessibility.Public, ["static"], item.UserProvidedPartials.PartialFrom)} {wrapperName}? FromNullable({itemUnderlyingType}? value)
+        {{
+            {Util.GenerateNullCheckAndReturnNullIfNeeded(item)}
+            {Util.GenerateFrom(itemUnderlyingType)}
+        }}
+
         {GenerateCodeForTryFrom.GenerateForAStruct(item, wrapperName, itemUnderlyingType)}
 
 {Util.GenerateIsInitializedMethod(@readonly: true, item)}

--- a/src/Vogen/Generators/StructGenerator.cs
+++ b/src/Vogen/Generators/StructGenerator.cs
@@ -92,6 +92,18 @@ public class StructGenerator : IGenerateValueObjectSourceCode
             return new {wrapperName}(value);
         }}
 
+        /// <summary>
+        /// Builds a nullable instance from the provided underlying type.
+        /// </summary>
+        /// <param name=""value"">The underlying type.</param>
+        /// <returns>An instance of this type.</returns>
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        {Util.GenerateMethodModifiers(Accessibility.Public, ["static"], item.UserProvidedPartials.PartialFrom)} {wrapperName}? FromNullable({itemUnderlyingType}? value)
+        {{
+            {Util.GenerateNullCheckAndReturnNullIfNeeded(item)}
+            {Util.GenerateFrom(itemUnderlyingType)}
+        }}
+
         {GenerateCodeForTryFrom.GenerateForAStruct(item, wrapperName, itemUnderlyingType)}
 
 {Util.GenerateIsInitializedMethod(@readonly: true, item)}

--- a/src/Vogen/Util.cs
+++ b/src/Vogen/Util.cs
@@ -30,6 +30,23 @@ internal static class Util
               """;
     }
 
+    public static string GenerateNullCheckAndReturnNullIfNeeded(VoWorkItem voWorkItem)
+    {
+        return 
+            """
+                if (value is null)
+                {
+                    return null;
+                }
+            """;
+    }
+    
+    public static string GenerateFrom(string itemUnderlyingType)
+    {
+        return
+            $"    return From(({itemUnderlyingType})value);";
+    }
+
     public static string GenerateMethodModifiers(
         Accessibility defaultAccessibility,
         IEnumerable<string> otherModifers,

--- a/tests/ConsumerTests/FromNullableTests.cs
+++ b/tests/ConsumerTests/FromNullableTests.cs
@@ -1,0 +1,53 @@
+using Vogen.Tests.Types;
+
+namespace ConsumerTests;
+
+[ValueObject(typeof(Guid))]
+public partial class GuidId;
+
+public class FromNullableTests
+{
+    public class Test_From_Nullable
+    {
+        [Fact]
+        public void Int()
+        {
+            Age? nullAge = Age.FromNullable(null);
+            Assert.Null(nullAge);
+            
+            Age? notNullAge = Age.FromNullable(32);
+            Assert.Equal(32, notNullAge?.Value);
+
+            Assert.Throws<ValueObjectValidationException>(() =>
+            {
+                Age? invalidDage = Age.FromNullable(10);
+            });
+        }
+        
+        [Fact]
+        public void String()
+        {
+            Dave? nullDave = Dave.FromNullable(null);
+            Assert.Null(nullDave);
+            
+            Dave? notNullDave = Dave.FromNullable("Dave Angel");
+            Assert.Equal("Dave Angel", notNullDave?.Value);
+
+            Assert.Throws<ValueObjectValidationException>(() =>
+            {
+                Dave? notDave = Dave.FromNullable("Elvis Presley");
+            });
+        }
+        
+        [Fact]
+        public void Guid()
+        {
+            GuidId? nullId = GuidId.FromNullable(null);
+            Assert.Null(nullId);
+
+            var id = System.Guid.NewGuid();
+            GuidId? notNullId = GuidId.FromNullable(id);
+            Assert.Equal(notNullId?.Value, id);
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/SteveDunn/Vogen/issues/875

Adds .FromNullable function to simplify working with null values:
```
[ValueObject<int>] public readonly partial struct CompanyId;

...
var result = SomeFunction.GetSomeStuff();
// CompanyId? id = result.CompanyId is null ? null : CompanyId.From(result.CompanyId.Value);
CompanyId? id = CompanyId.FromNullable(result.CompanyId);
```
