### PR TITLE
Fix Activator.CreateInstance syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ var c = default(CustomerId); // error VOG009: Type 'CustomerId' cannot be constr
 var c = GetCustomerId(); // error VOG010: Type 'CustomerId' cannot be constructed with 'new' as it is prohibited
 
 var c = Activator.CreateInstance<CustomerId>(); // error VOG025: Type 'CustomerId' cannot be constructed via Reflection as it is prohibited.
-var c = Activator.CreateInstance(<CustomerId>); // error VOG025: Type 'CustomerId' cannot be constructed via Reflection as it is prohibited.
+var c = Activator.CreateInstance(typeof(CustomerId)); // error VOG025: Type 'CustomerId' cannot be constructed via Reflection as it is prohibited.
 
 // catches lambda expressions
 Func<CustomerId> f = () => default; // error VOG009: Type 'CustomerId' cannot be constructed with default as it is prohibited.


### PR DESCRIPTION
Just spotted this while reading through the docs. I think the intent here was to show both overloads of Activator.CreateInstance?