### PR TITLE
fix: correct protobuf-net surrogate example in docs

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -1,0 +1,56 @@
+# Fenster's History
+
+## Learnings
+
+### 2026-05-05: Issue #838 - Protobuf Surrogate Investigation
+
+**Issue**: GitHub issue #838 reports that the README example for protobuf-net usage fails with:
+```
+'Data of this type has inbuilt behaviour, and cannot be added to a model in this way: System.String'
+```
+
+**Investigation Summary**:
+
+1. **Vogen does NOT generate protobuf-specific code**
+   - Searched entire `src/Vogen/` directory
+   - No protobuf-related code generation exists
+   - No `Conversions.ProtoBuf` flag in `src/Vogen.SharedTypes/Conversions.cs` (only has: TypeConverter, NewtonsoftJson, SystemTextJson, EfCoreValueConverter, DapperTypeHandler, LinqToDbValueConverter, ServiceStackDotText, Bson, Orleans, XmlSerializable, MessagePack)
+   - The only static constructor generation is in `src/Vogen/GenerateCodeForStaticConstructors.cs` (lines 36-100) for **ServiceStack only**
+
+2. **The Problem is in the Documentation**
+   - Current README (line 624) and FAQ (line 428) show this pattern:
+     ```csharp
+     [ValueObject<string>]
+     [ProtoContract(Surrogate = typeof(string))]
+     public partial class BoxId;
+     ```
+   - This pattern is **INVALID** according to protobuf-net documentation
+   - You **CANNOT** use a primitive type like `string` as a surrogate in protobuf-net
+   - protobuf-net throws the error when `SchemaGenerator` or `RuntimeTypeModel` encounters this pattern
+
+3. **Root Cause**
+   - When `protobuf-net.Grpc.Reflection.SchemaGenerator` scans types, it discovers `BoxId` with `[ProtoContract(Surrogate = typeof(string))]`
+   - It tries to register: `RuntimeTypeModel.Default.Add(typeof(BoxId), ...).SetSurrogate(typeof(string))`
+   - protobuf-net rejects this because `string` has "inbuilt behaviour" and cannot be a surrogate target
+   - **A surrogate MUST be a [ProtoContract] class, not a primitive**
+
+4. **The Fix**
+   - The documentation pattern in README.md (line 624) and FAQ.md (line 428) is incorrect and should be removed or corrected
+   - Users should NOT use `[ProtoContract(Surrogate = typeof(string))]` on their ValueObjects
+   - Correct approaches:
+     - **Option A**: Don't use `[ProtoContract]` at all - let protobuf-net serialize the `Value` property directly
+     - **Option B**: Create a proper surrogate class (a `[ProtoContract]` type with conversion logic) if custom serialization is needed
+     - **Option C**: Add a `Conversions.ProtoBuf` flag to Vogen and generate proper surrogate classes (future enhancement)
+
+**Files Examined**:
+- `src/Vogen/GenerateCodeForStaticConstructors.cs` - Only generates for ServiceStack
+- `src/Vogen/GenerateCodeForOrleansSerializers.cs` - Orleans-specific, not protobuf
+- `src/Vogen/Generators/ClassGenerator.cs` (line 65) - Calls GenerateCodeForStaticConstructors
+- `src/Vogen/Generators/StructGenerator.cs` (line 65) - Calls GenerateCodeForStaticConstructors
+- `src/Vogen/Generators/RecordClassGenerator.cs` (line 75) - Calls GenerateCodeForStaticConstructors
+- `src/Vogen/Generators/RecordStructGenerator.cs` (line 74) - Calls GenerateCodeForStaticConstructors
+- `src/Vogen.SharedTypes/Conversions.cs` - No protobuf flag exists
+- `tests/SnapshotTests/` - No protobuf-related snapshot tests found
+
+**Conclusion**:
+This is not a bug in Vogen's code generation. It's **incorrect documentation** that suggests an invalid protobuf-net pattern. The README should be corrected to remove or fix the protobuf example.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -18,6 +18,45 @@
 
 ---
 
+## 2026-05-05: Fix Issue #838 - Incorrect Protobuf Documentation
+
+**By:** Fenster (Backend Dev)
+
+**What:** Fix documentation errors in README.md and FAQ.md regarding protobuf-net surrogate configuration.
+
+**Context:** GitHub issue #838 reported that the documented protobuf pattern `Surrogate = typeof(string)` fails in protobuf-net v3 with error: `'Data of this type has inbuilt behaviour, and cannot be added to a model in this way: System.String'`
+
+**Investigation Findings:**
+- Vogen does NOT generate protobuf-specific code; no `Conversions.ProtoBuf` flag exists
+- The documented pattern is invalid per protobuf-net rules: you cannot use a primitive type like `string` as a surrogate
+- A surrogate type MUST be a `[ProtoContract]` class, not a primitive
+- This is a documentation issue, NOT a code generation bug
+
+**Decision:** Fix the documentation by replacing the invalid pattern with a correct surrogate DTO class pattern:
+```csharp
+[ProtoContract]
+public class StringSurrogate
+{
+    [ProtoMember(1)]
+    public string Value { get; set; }
+}
+
+[ValueObject(Surrogate = typeof(StringSurrogate))]
+public partial struct MyValueObject;
+```
+
+**Files Changed:**
+- README.md — updated protobuf surrogate example
+- docs/site/Writerside/topics/reference/FAQ.md — corrected FAQ entry with working pattern and explanatory note
+
+**Commit:** 6f6e919302
+
+**Why:** Prevents users from encountering serialization errors; aligns documentation with protobuf-net v3 requirements.
+
+**Future:** Consider adding proper protobuf support (Option 3) as a feature enhancement in next quarter.
+
+---
+
 ## End of decisions
 
 New decisions will be merged here by Scribe from `.squad/decisions/inbox/`.

--- a/README.md
+++ b/README.md
@@ -617,18 +617,28 @@ Linq2DB 4.0 or greater supports `DateOnly` and `TimeOnly`. Vogen generates value
 
 ### Can I use protobuf-net?
 
-Yes. Add a dependency to protobuf-net and set a surrogate attribute:
+Yes. Add a dependency to protobuf-net and create a surrogate class with the appropriate conversion operators, then reference it via `[ProtoContract(Surrogate = ...)]`:
 
 ```csharp
 [ValueObject<string>]
-[ProtoContract(Surrogate = typeof(string))]
-public partial class BoxId {
-//...
+[ProtoContract(Surrogate = typeof(BoxIdSurrogate))]
+public partial class BoxId;
+
+[ProtoContract]
+public class BoxIdSurrogate
+{
+    [ProtoMember(1)]
+    public string Value { get; set; } = "";
+
+    public static implicit operator BoxId(BoxIdSurrogate surrogate) => BoxId.From(surrogate.Value);
+    public static implicit operator BoxIdSurrogate(BoxId value) => new() { Value = value.Value };
 }
 ```
 
-BoxId type now will be serialized as a string in all messages/grpc calls. If one is generating .proto files for other 
-applications from C# code, proto files will include Surrogate type as the type. 
+BoxId will be serialized using the surrogate in all messages and gRPC calls.
+
+> **Note:** Do not use `[ProtoContract(Surrogate = typeof(string))]` — protobuf-net v3 treats `string` (and other primitives) as built-in types and will throw `'Data of this type has inbuilt behaviour, and cannot be added to a model in this way: System.String'` at runtime, including when generating `.proto` schemas via `SchemaGenerator`. Use a dedicated surrogate class instead.
+
 _thank you to [@DomasM](https://github.com/DomasM) for this information_.
 
 ## Thanks

--- a/README.md
+++ b/README.md
@@ -617,29 +617,7 @@ Linq2DB 4.0 or greater supports `DateOnly` and `TimeOnly`. Vogen generates value
 
 ### Can I use protobuf-net?
 
-Yes. Add a dependency to protobuf-net and create a surrogate class with the appropriate conversion operators, then reference it via `[ProtoContract(Surrogate = ...)]`:
-
-```csharp
-[ValueObject<string>]
-[ProtoContract(Surrogate = typeof(BoxIdSurrogate))]
-public partial class BoxId;
-
-[ProtoContract]
-public class BoxIdSurrogate
-{
-    [ProtoMember(1)]
-    public string Value { get; set; } = "";
-
-    public static implicit operator BoxId(BoxIdSurrogate surrogate) => BoxId.From(surrogate.Value);
-    public static implicit operator BoxIdSurrogate(BoxId value) => new() { Value = value.Value };
-}
-```
-
-BoxId will be serialized using the surrogate in all messages and gRPC calls.
-
-> **Note:** Do not use `[ProtoContract(Surrogate = typeof(string))]` — protobuf-net v3 treats `string` (and other primitives) as built-in types and will throw `'Data of this type has inbuilt behaviour, and cannot be added to a model in this way: System.String'` at runtime, including when generating `.proto` schemas via `SchemaGenerator`. Use a dedicated surrogate class instead.
-
-_thank you to [@DomasM](https://github.com/DomasM) for this information_.
+Yes. See the [FAQ](docs/site/Writerside/topics/reference/FAQ.md#can-i-use-protobuf-net) for details and a worked example.
 
 ## Thanks
 

--- a/docs/site/Writerside/topics/reference/FAQ.md
+++ b/docs/site/Writerside/topics/reference/FAQ.md
@@ -421,27 +421,34 @@ Linq2DB 4.0 or greater supports `DateOnly` and `TimeOnly`. Vogen generates value
 
 ## Can I use protobuf-net?
 
-Yes. Add a dependency to protobuf-net and create a surrogate class with the appropriate conversion operators, then reference it via `[ProtoContract(Surrogate = ...)]`:
+Yes. Add a dependency to protobuf-net and use a generic surrogate class that works across all your value objects:
 
 ```c#
-[ValueObject(typeof(string))]
-[ProtoContract(Surrogate = typeof(BoxIdSurrogate))]
+[ValueObject<string>]
+[ProtoContract(Surrogate = typeof(VogenSurrogate<BoxId, string>))]
 public partial class BoxId;
 
+[ValueObject<int>]
+[ProtoContract(Surrogate = typeof(VogenSurrogate<Age, int>))]
+public partial class Age;
+
 [ProtoContract]
-public class BoxIdSurrogate
+public class VogenSurrogate<TW, TP> where TW : IVogen<TW, TP>
 {
     [ProtoMember(1)]
     public string Value { get; set; } = "";
 
-    public static implicit operator BoxId(BoxIdSurrogate surrogate) => BoxId.From(surrogate.Value);
-    public static implicit operator BoxIdSurrogate(BoxId value) => new() { Value = value.Value };
+    public static implicit operator BoxId(VogenSurrogate<TW, TP> surrogate) => BoxId.From(surrogate.Value);
+    public static implicit operator VogenSurrogate<TW, TP>(BoxId value) => new() { Value = value.Value };
 }
 ```
 
-The BoxId type will be serialized using the surrogate in all messages and gRPC calls.
+The generic `VogenSurrogate<TW, TP>` can be defined once and reused for every value object in your project.
 
-> **Note:** Do not use `[ProtoContract(Surrogate = typeof(string))]` — protobuf-net v3 treats `string` (and other primitives) as built-in types and will throw `'Data of this type has inbuilt behaviour, and cannot be added to a model in this way: System.String'` at runtime, including when generating `.proto` schemas via `SchemaGenerator`. Use a dedicated surrogate class instead.
+> **Note:** Do not use `[ProtoContract(Surrogate = typeof(string))]` — protobuf-net v3 treats `string` (and other primitives) as built-in types and will throw `'Data of this type has inbuilt behaviour, and cannot be added to a model in this way: System.String'` at runtime, including when generating `.proto` schemas via `SchemaGenerator`. Use a surrogate class instead.
+
+A full working example including schema generation and a gRPC service can be found in
+[`samples/Vogen.Examples/SerializationAndConversion/Grpc/GrpcScenario.cs`](../../../../samples/Vogen.Examples/SerializationAndConversion/Grpc/GrpcScenario.cs).
 
 _thank you to [@DomasM](https://github.com/DomasM) for this information_.
 

--- a/docs/site/Writerside/topics/reference/FAQ.md
+++ b/docs/site/Writerside/topics/reference/FAQ.md
@@ -421,7 +421,42 @@ Linq2DB 4.0 or greater supports `DateOnly` and `TimeOnly`. Vogen generates value
 
 ## Can I use protobuf-net?
 
-Yes. Add a dependency to protobuf-net and use a generic surrogate class that works across all your value objects:
+### protobuf-net v2 (pre-v3)
+
+Yes. Add a dependency to protobuf-net and annotate the value object with `[ProtoContract(Surrogate = typeof(string))]`:
+
+```c#
+[ValueObject<string>]
+[ProtoContract(Surrogate = typeof(string))]
+public partial class Name;
+```
+
+_thank you to [@DomasM](https://github.com/DomasM) for this information_.
+
+### protobuf-net v3 (and later)
+
+In v3, primitive types such as `string` and `int` are registered as built-in types. Attempting to use them as surrogates (e.g. `[ProtoContract(Surrogate = typeof(string))]`) will throw:
+
+> `'Data of this type has inbuilt behaviour, and cannot be added to a model in this way: System.String'`
+
+This error occurs at runtime and also when generating `.proto` schemas via `SchemaGenerator`.
+
+The solution is a generic surrogate class that you define once and reuse across all your value objects:
+
+```c#
+// TW = wrapper type, TP = primitive (underlying) type
+[ProtoContract]
+public class VogenSurrogate<TW, TP> where TW : IVogen<TW, TP>
+{
+    [ProtoMember(1)]
+    public TP Value { get; set; }
+
+    public static implicit operator TW(VogenSurrogate<TW, TP> surrogate) => TW.From(surrogate.Value);
+    public static implicit operator VogenSurrogate<TW, TP>(TW value) => new() { Value = value.Value };
+}
+```
+
+Then annotate each value object with the appropriate closed generic:
 
 ```c#
 [ValueObject<string>]
@@ -431,26 +466,10 @@ public partial class BoxId;
 [ValueObject<int>]
 [ProtoContract(Surrogate = typeof(VogenSurrogate<Age, int>))]
 public partial class Age;
-
-[ProtoContract]
-public class VogenSurrogate<TW, TP> where TW : IVogen<TW, TP>
-{
-    [ProtoMember(1)]
-    public string Value { get; set; } = "";
-
-    public static implicit operator BoxId(VogenSurrogate<TW, TP> surrogate) => BoxId.From(surrogate.Value);
-    public static implicit operator VogenSurrogate<TW, TP>(BoxId value) => new() { Value = value.Value };
-}
 ```
-
-The generic `VogenSurrogate<TW, TP>` can be defined once and reused for every value object in your project.
-
-> **Note:** Do not use `[ProtoContract(Surrogate = typeof(string))]` — protobuf-net v3 treats `string` (and other primitives) as built-in types and will throw `'Data of this type has inbuilt behaviour, and cannot be added to a model in this way: System.String'` at runtime, including when generating `.proto` schemas via `SchemaGenerator`. Use a surrogate class instead.
 
 A full working example including schema generation and a gRPC service can be found in
 [`samples/Vogen.Examples/SerializationAndConversion/Grpc/GrpcScenario.cs`](../../../../samples/Vogen.Examples/SerializationAndConversion/Grpc/GrpcScenario.cs).
-
-_thank you to [@DomasM](https://github.com/DomasM) for this information_.
 
 ## Can I have a factory method for value objects that wrap GUIDs?
 

--- a/docs/site/Writerside/topics/reference/FAQ.md
+++ b/docs/site/Writerside/topics/reference/FAQ.md
@@ -421,16 +421,27 @@ Linq2DB 4.0 or greater supports `DateOnly` and `TimeOnly`. Vogen generates value
 
 ## Can I use protobuf-net?
 
-Yes. Add a dependency to protobuf-net and set a surrogate attribute:
+Yes. Add a dependency to protobuf-net and create a surrogate class with the appropriate conversion operators, then reference it via `[ProtoContract(Surrogate = ...)]`:
 
 ```c#
 [ValueObject(typeof(string))]
-[ProtoContract(Surrogate = typeof(string))]
+[ProtoContract(Surrogate = typeof(BoxIdSurrogate))]
 public partial class BoxId;
+
+[ProtoContract]
+public class BoxIdSurrogate
+{
+    [ProtoMember(1)]
+    public string Value { get; set; } = "";
+
+    public static implicit operator BoxId(BoxIdSurrogate surrogate) => BoxId.From(surrogate.Value);
+    public static implicit operator BoxIdSurrogate(BoxId value) => new() { Value = value.Value };
+}
 ```
 
-The BoxId type will now be serialized as a `string` in all messages and grpc calls. If one is generating `.proto` files
-for other applications from C#, proto files will include the `Surrogate` type as the type.
+The BoxId type will be serialized using the surrogate in all messages and gRPC calls.
+
+> **Note:** Do not use `[ProtoContract(Surrogate = typeof(string))]` — protobuf-net v3 treats `string` (and other primitives) as built-in types and will throw `'Data of this type has inbuilt behaviour, and cannot be added to a model in this way: System.String'` at runtime, including when generating `.proto` schemas via `SchemaGenerator`. Use a dedicated surrogate class instead.
 
 _thank you to [@DomasM](https://github.com/DomasM) for this information_.
 

--- a/docs/site/Writerside/topics/reference/FAQ.md
+++ b/docs/site/Writerside/topics/reference/FAQ.md
@@ -420,10 +420,11 @@ Linq2DB 4.0 or greater supports `DateOnly` and `TimeOnly`. Vogen generates value
 `MappingSchema.Default.SetConverter<DateTime, TimeOnly>(dt => TimeOnly.FromDateTime(dt));`
 
 ## Can I use protobuf-net?
+Yes, but the mechanism is different depending on the version of protobuf-net you are using.
 
 ### protobuf-net v2 (pre-v3)
 
-Yes. Add a dependency to protobuf-net and annotate the value object with `[ProtoContract(Surrogate = typeof(string))]`:
+Add a dependency to protobuf-net and annotate the value object with `[ProtoContract(Surrogate = typeof(string))]`: (NOTE: replace `string` with the correct primitive)
 
 ```c#
 [ValueObject<string>]

--- a/samples/Vogen.Examples/Program.cs
+++ b/samples/Vogen.Examples/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Vogen.Examples.SerializationAndConversion.Grpc;
 
 namespace Vogen.Examples
 {
@@ -35,6 +36,7 @@ namespace MediumTests.SerializationAndConversionTests
         // ReSharper disable once UnusedParameter.Local
         static async Task Main(string[] args)
         {
+            await new GrpcScenario().Run();
             try
             {
                 var scenarioTypes = typeof(Program).Assembly.GetTypes()

--- a/samples/Vogen.Examples/Program.cs
+++ b/samples/Vogen.Examples/Program.cs
@@ -36,7 +36,6 @@ namespace MediumTests.SerializationAndConversionTests
         // ReSharper disable once UnusedParameter.Local
         static async Task Main(string[] args)
         {
-            await new GrpcScenario().Run();
             try
             {
                 var scenarioTypes = typeof(Program).Assembly.GetTypes()

--- a/samples/Vogen.Examples/SerializationAndConversion/Grpc/GrpcScenario.cs
+++ b/samples/Vogen.Examples/SerializationAndConversion/Grpc/GrpcScenario.cs
@@ -70,14 +70,15 @@ public partial class Age;
 [ProtoContract(Surrogate = typeof(VogenSurrogate<Temperature, double>))]
 public partial class Temperature;
 
+// TW = wrapper, TP = primitive (underlying)
 [ProtoContract]
 public class VogenSurrogate<TW, TP> where TW: IVogen<TW, TP>
 {
     [ProtoMember(1)]
-    public string Value { get; set; } = "";
+    public TP Value { get; set; }
 
-    public static implicit operator BoxId(VogenSurrogate<TW, TP> surrogate) => BoxId.From(surrogate.Value);
-    public static implicit operator VogenSurrogate<TW, TP>(BoxId value) => new() { Value = value.Value };
+    public static implicit operator TW(VogenSurrogate<TW, TP> surrogate) => TW.From(surrogate.Value);
+    public static implicit operator VogenSurrogate<TW, TP>(TW value) => new() { Value = value.Value };
 }
 
 

--- a/samples/Vogen.Examples/SerializationAndConversion/Grpc/GrpcScenario.cs
+++ b/samples/Vogen.Examples/SerializationAndConversion/Grpc/GrpcScenario.cs
@@ -1,0 +1,58 @@
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using ProtoBuf;
+using System.ServiceModel;
+
+namespace Vogen.Examples.SerializationAndConversion.Grpc;
+
+
+[ValueObject(typeof(string))]
+[ProtoContract(Surrogate = typeof(BoxIdSurrogate))]
+public partial class BoxId;
+
+[ProtoContract]
+public class BoxIdSurrogate
+{
+    [ProtoMember(1)]
+    public string Value { get; set; } = "";
+
+    public static implicit operator BoxId(BoxIdSurrogate surrogate) => BoxId.From(surrogate.Value);
+    public static implicit operator BoxIdSurrogate(BoxId value) => new() { Value = value.Value };
+}
+
+
+[UsedImplicitly]
+public class GrpcScenario : IScenario
+{
+    public async Task Run()
+    {
+        var generator = new ProtoBuf.Grpc.Reflection.SchemaGenerator();
+
+        string schema = generator.GetSchema<IService>();
+        
+        IService service = new Service();
+        BoxId boxId = await service.GetDataAsync();
+        
+        Console.WriteLine($"Received BoxId: {boxId}");
+    }
+}
+
+[ServiceContract]
+public interface IService
+{
+    Task<BoxId> GetDataAsync(CancellationToken cancellation = default);
+}
+
+public class Service : IService
+{
+    public Task<BoxId> GetDataAsync(CancellationToken cancellation = default)
+    {
+        return Task.FromResult(BoxId.From("hardcoded-box-id"));
+    }
+}
+
+
+

--- a/samples/Vogen.Examples/SerializationAndConversion/Grpc/GrpcScenario.cs
+++ b/samples/Vogen.Examples/SerializationAndConversion/Grpc/GrpcScenario.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,22 +7,6 @@ using System.ServiceModel;
 
 namespace Vogen.Examples.SerializationAndConversion.Grpc;
 
-
-[ValueObject(typeof(string))]
-[ProtoContract(Surrogate = typeof(BoxIdSurrogate))]
-public partial class BoxId;
-
-[ProtoContract]
-public class BoxIdSurrogate
-{
-    [ProtoMember(1)]
-    public string Value { get; set; } = "";
-
-    public static implicit operator BoxId(BoxIdSurrogate surrogate) => BoxId.From(surrogate.Value);
-    public static implicit operator BoxIdSurrogate(BoxId value) => new() { Value = value.Value };
-}
-
-
 [UsedImplicitly]
 public class GrpcScenario : IScenario
 {
@@ -32,27 +15,71 @@ public class GrpcScenario : IScenario
         var generator = new ProtoBuf.Grpc.Reflection.SchemaGenerator();
 
         string schema = generator.GetSchema<IService>();
+        Console.WriteLine("Schema is: " + schema);
         
         IService service = new Service();
-        BoxId boxId = await service.GetDataAsync();
+        var person = await service.GetDataAsync();
         
-        Console.WriteLine($"Received BoxId: {boxId}");
+        Console.WriteLine($"Received Person:  name={person.Name}, age={person.Age}, boxId={person.BoxId}, temperature={person.Temperature}");
     }
+}
+
+public class Person
+{
+    public Name Name { get; init; }
+    public Age Age { get; init; }
+    public BoxId BoxId { get; init; }
+    public Temperature Temperature { get; init; }
 }
 
 [ServiceContract]
 public interface IService
 {
-    Task<BoxId> GetDataAsync(CancellationToken cancellation = default);
+    Task<Person> GetDataAsync(CancellationToken cancellation = default);
 }
 
 public class Service : IService
 {
-    public Task<BoxId> GetDataAsync(CancellationToken cancellation = default)
+    public Task<Person> GetDataAsync(CancellationToken cancellation = default)
     {
-        return Task.FromResult(BoxId.From("hardcoded-box-id"));
+        return Task.FromResult(
+            new Person
+            {
+                Age = Age.From(42),
+                BoxId = BoxId.From("123"),
+                Name = Name.From("Fred"),
+                Temperature = Temperature.From(12.3)
+            }
+        );
     }
 }
+
+[ValueObject<string>]
+[ProtoContract(Surrogate = typeof(VogenSurrogate<BoxId, string>))]
+public partial class BoxId;
+
+[ValueObject<string>]
+[ProtoContract(Surrogate = typeof(VogenSurrogate<Name, string>))]
+public partial class Name;
+
+[ValueObject<int>]
+[ProtoContract(Surrogate = typeof(VogenSurrogate<Age, int>))]
+public partial class Age;
+
+[ValueObject<double>]
+[ProtoContract(Surrogate = typeof(VogenSurrogate<Temperature, double>))]
+public partial class Temperature;
+
+[ProtoContract]
+public class VogenSurrogate<TW, TP> where TW: IVogen<TW, TP>
+{
+    [ProtoMember(1)]
+    public string Value { get; set; } = "";
+
+    public static implicit operator BoxId(VogenSurrogate<TW, TP> surrogate) => BoxId.From(surrogate.Value);
+    public static implicit operator VogenSurrogate<TW, TP>(BoxId value) => new() { Value = value.Value };
+}
+
 
 
 

--- a/samples/Vogen.Examples/SerializationAndConversion/SerializationAndConversion.cs
+++ b/samples/Vogen.Examples/SerializationAndConversion/SerializationAndConversion.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS0219
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using ServiceStack.Text;
 using Vogen.Examples.Types;

--- a/samples/Vogen.Examples/Vogen.Examples.csproj
+++ b/samples/Vogen.Examples/Vogen.Examples.csproj
@@ -20,10 +20,16 @@
 
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+		<PackageReference Include="protobuf-net" Version="3.2.56" />
+		<PackageReference Include="protobuf-net.Grpc" Version="1.2.2" />
+		<PackageReference Include="protobuf-net.Grpc.Reflection" Version="1.2.2" />
+		<PackageReference Include="protobuf-net.Reflection" Version="3.2.52" />
 		<PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.9" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
 
 		<PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+
+		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Dapper" Version="2.0.123" />


### PR DESCRIPTION
The documented pattern [ProtoContract(Surrogate = typeof(string))] does not work with protobuf-net v3 because string (and other primitives) are built-in types that cannot be registered as surrogates. The library throws 'Data of this type has inbuilt behaviour, and cannot be added to a model in this way: System.String' at runtime, both during normal serialization setup and when using SchemaGenerator.

Replace with the correct pattern: a dedicated surrogate DTO class annotated with [ProtoContract] and [ProtoMember(1)], with implicit conversion operators to/from the value object.

Fixes #838