### PR TITLE
EFCore analyzer improvements

### DIFF
--- a/src/Vogen/AnalyzerReleases.Unshipped.md
+++ b/src/Vogen/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,11 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+VOG039 | Usage | Warning | DoNotAccessValueInEfCoreAnalyzer
+
+
+### Changed Rules
+
+Rule ID | New Category | New Severity | Old Category | Old Severity | Notes
+--------|--------------|--------------|--------------|--------------|-------
+VOG034 | Usage | Warning | Usage | Error | DoNotCompareWithPrimitivesInEfCoreAnalyzer

--- a/src/Vogen/Diagnostics/RuleIdentifiers.cs
+++ b/src/Vogen/Diagnostics/RuleIdentifiers.cs
@@ -44,4 +44,5 @@ public static class RuleIdentifiers
     public const string VoReferencedInAConversionMarkerMustExplicitlySpecifyPrimitive = "VOG035";
     public const string BothImplicitAndExplicitCastsSpecified = "VOG036";
     public const string NumericsGenerationNotApplicable = "VOG037";
+    public const string DoNotAccessValueInEfCore = "VOG039";
 }

--- a/src/Vogen/Rules/DoNotAccessValueInEfCoreAnalyzer.cs
+++ b/src/Vogen/Rules/DoNotAccessValueInEfCoreAnalyzer.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Vogen.Diagnostics;
+
+namespace Vogen.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class DoNotAccessValueInEfCoreAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor _rule = new(
+        RuleIdentifiers.DoNotAccessValueInEfCore,
+        "Directly accessing the value in EFCore expressions cannot be translated",
+        "The value of object '{0}' is being accessed directly. Cast it to its primitive instead.",
+        RuleCategories.Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+        "EFCore cannot translate the access to the underlying value of an value object. You need to cast the object to its primitive.");
+
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        var hasEfCoreRef = context.Compilation.GetTypeByMetadataName("Microsoft.EntityFrameworkCore.DbSet`1") is not null;
+
+        if (!hasEfCoreRef)
+        {
+            return;
+        }
+        
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeQueryExpression, SyntaxKind.QueryExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        if (VoFilter.IsInCodeThatShouldNotBeAnalyzed(context.Node)) return;
+        
+        var invocationExpr = (InvocationExpressionSyntax) context.Node;
+
+        if (context.SemanticModel.GetSymbolInfo(invocationExpr).Symbol is not IMethodSymbol methodSymbol)
+        {
+            return;
+        }
+
+        if (!EfCoreAnalyzerHelper.IsLinqToEntities(methodSymbol, context.SemanticModel.Compilation))
+        {
+            return;
+        }
+
+        foreach (ArgumentSyntax eachArgument in
+                 invocationExpr.ArgumentList.Arguments.Where(e => e.Expression is LambdaExpressionSyntax))
+        {
+            foreach (MemberAccessExpressionSyntax eachMemberAccess in eachArgument.DescendantNodes().OfType<MemberAccessExpressionSyntax>())
+            {
+                if (eachMemberAccess.Name.Identifier.Text != "Value")
+                {
+                    continue;
+                }
+
+                ITypeSymbol? expressionType = context.SemanticModel.GetTypeInfo(eachMemberAccess.Expression).Type;
+
+                if (expressionType is null)
+                {
+                    continue;
+                }
+
+                if (EfCoreAnalyzerHelper.IsValueObject(expressionType))
+                {
+                    context.ReportDiagnostic(
+                        DiagnosticsCatalogue.BuildDiagnostic(_rule, expressionType.Name, eachMemberAccess.GetLocation()));
+                }
+            }
+        }
+    }
+
+    private static void AnalyzeQueryExpression(SyntaxNodeAnalysisContext context)
+    {
+        if (VoFilter.IsInCodeThatShouldNotBeAnalyzed(context.Node)) return;
+
+        var queryExpr = (QueryExpressionSyntax) context.Node;
+
+        if (!EfCoreAnalyzerHelper.IsEfQuery(queryExpr, context.SemanticModel))
+        {
+            return;
+        }
+
+        foreach (MemberAccessExpressionSyntax eachMemberAccess in queryExpr.Body.DescendantNodes().OfType<MemberAccessExpressionSyntax>())
+        {
+            if (eachMemberAccess.Name.Identifier.Text != "Value")
+            {
+                continue;
+            }
+
+            ITypeSymbol? expressionType = context.SemanticModel.GetTypeInfo(eachMemberAccess.Expression).Type;
+
+            if (expressionType is null)
+            {
+                continue;
+            }
+
+            if (EfCoreAnalyzerHelper.IsValueObject(expressionType))
+            {
+                context.ReportDiagnostic(
+                    DiagnosticsCatalogue.BuildDiagnostic(_rule, expressionType.Name, eachMemberAccess.GetLocation()));
+            }
+        }
+    }
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [_rule];
+}

--- a/src/Vogen/Rules/DoNotCompareWithPrimitivesInEfCoreAnalyzer.cs
+++ b/src/Vogen/Rules/DoNotCompareWithPrimitivesInEfCoreAnalyzer.cs
@@ -11,9 +11,6 @@ namespace Vogen.Rules;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class DoNotCompareWithPrimitivesInEfCoreAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly ImmutableHashSet<string> _knownNames =
-        new[] { "Where", "Single", "SkipWhile", "TakeWhile", "Select" }.ToImmutableHashSet();
-
     // ReSharper disable once ArrangeObjectCreationWhenTypeEvident - current bug in Roslyn analyzer means it
     // won't find this and will report:
     // "error RS2002: Rule 'XYZ123' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer"
@@ -22,7 +19,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzer : DiagnosticAnalyzer
         "Comparing primitives with value objects in EFCore expressions can cause casting issues",
         "Value object '{0}' is being compared to an int. Compare it with the value object instead.",
         RuleCategories.Usage,
-        DiagnosticSeverity.Error,
+        DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description:
         "The value object is being compared with a primitive in an EFCore expression. This can lead to EFCore trying and failing to cast between the two.");
@@ -37,6 +34,18 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
         context.EnableConcurrentExecution();
 
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+    
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        var hasEfCoreRef = context.Compilation.GetTypeByMetadataName("Microsoft.EntityFrameworkCore.DbSet`1") is not null;
+
+        if (!hasEfCoreRef)
+        {
+            return;
+        }
+        
         context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
         context.RegisterSyntaxNodeAction(AnalyzeQueryExpression, SyntaxKind.QueryExpression);
     }
@@ -46,19 +55,13 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzer : DiagnosticAnalyzer
         if (VoFilter.IsInCodeThatShouldNotBeAnalyzed(context.Node)) return;
 
         var invocationExpr = (InvocationExpressionSyntax) context.Node;
-        if (invocationExpr.Expression is not MemberAccessExpressionSyntax memberAccessExpr)
+
+        if (context.SemanticModel.GetSymbolInfo(invocationExpr).Symbol is not IMethodSymbol methodSymbol)
         {
             return;
         }
 
-        if (!_knownNames.Contains(memberAccessExpr.Name.Identifier.Text))
-        {
-            return;
-        }
-
-        ExpressionSyntax expressionSyntax = memberAccessExpr.Expression;
-
-        if (!IsAMemberOfDbSet(context, expressionSyntax))
+        if (!EfCoreAnalyzerHelper.IsLinqToEntities(methodSymbol, context.SemanticModel.Compilation))
         {
             return;
         }
@@ -77,7 +80,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzer : DiagnosticAnalyzer
                 }
 
                 // Check if left is ValueObject and right is integer
-                if (IsValueObject(left) && right.SpecialType == SpecialType.System_Int32)
+                if (EfCoreAnalyzerHelper.IsValueObject(left) && right.SpecialType == SpecialType.System_Int32)
                 {
                     context.ReportDiagnostic(
                         DiagnosticsCatalogue.BuildDiagnostic(_rule, left.Name, eachBinaryExpression.GetLocation()));
@@ -91,13 +94,13 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzer : DiagnosticAnalyzer
         if (VoFilter.IsInCodeThatShouldNotBeAnalyzed(context.Node)) return;
 
         var queryExpr = (QueryExpressionSyntax) context.Node;
-        var whereClauses = queryExpr.Body.DescendantNodes().OfType<WhereClauseSyntax>();
-        var fromClause = queryExpr.FromClause;
 
-        if (!IsAMemberOfDbSet(context, fromClause.Expression))
+        if (!EfCoreAnalyzerHelper.IsEfQuery(queryExpr, context.SemanticModel))
         {
             return;
         }
+
+        var whereClauses = queryExpr.Body.DescendantNodes().OfType<WhereClauseSyntax>();
 
         foreach (var eachArgument in whereClauses)
         {
@@ -112,7 +115,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzer : DiagnosticAnalyzer
                 }
 
                 // Check if left is ValueObject and right is integer
-                if (IsValueObject(left) && right.SpecialType == SpecialType.System_Int32)
+                if (EfCoreAnalyzerHelper.IsValueObject(left) && right.SpecialType == SpecialType.System_Int32)
                 {
                     context.ReportDiagnostic(
                         DiagnosticsCatalogue.BuildDiagnostic(_rule, left.Name, eachBinaryExpression.GetLocation()));
@@ -121,58 +124,4 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool IsAMemberOfDbSet(SyntaxNodeAnalysisContext context, ExpressionSyntax expressionSyntax)
-    {
-        var symbolInfo = context.SemanticModel.GetSymbolInfo(expressionSyntax);
-
-        ITypeSymbol? typeSymbol = null;
-
-        if (symbolInfo.Symbol is IPropertySymbol ps)
-        {
-            typeSymbol = ps.Type;
-        }
-
-        if (symbolInfo.Symbol is ILocalSymbol ls)
-        {
-            typeSymbol = ls.Type;
-        }
-
-        if (typeSymbol is null)
-        {
-            return false;
-        }
-
-        var dbSetType = context.SemanticModel.Compilation.GetTypeByMetadataName("Microsoft.EntityFrameworkCore.DbSet`1");
-
-        if (dbSetType is null)
-        {
-            return false;
-        }
-
-        return InheritsFrom(typeSymbol, dbSetType);
-    }
-
-
-    private static bool IsValueObject(ITypeSymbol type) =>
-        type is INamedTypeSymbol symbol && VoFilter.IsTarget(symbol);
-
-    private static bool InheritsFrom(ITypeSymbol? type, INamedTypeSymbol? baseType)
-    {
-        if (baseType is null)
-        {
-            return false;
-        }
-
-        while (type != null)
-        {
-            if (SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, baseType))
-            {
-                return true;
-            }
-
-            type = type.BaseType!;
-        }
-
-        return false;
-    }
 }

--- a/src/Vogen/Rules/EfCoreAnalyzerHelper.cs
+++ b/src/Vogen/Rules/EfCoreAnalyzerHelper.cs
@@ -1,0 +1,71 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Vogen.Rules;
+
+internal static class EfCoreAnalyzerHelper
+{
+    public static bool IsLinqToEntities(IMethodSymbol methodSymbol, Compilation compilation)
+    {
+        if (methodSymbol.ContainingType.EscapedFullName() == "System.Linq.Queryable")
+        {
+            return true;
+        }
+
+        var dbSetType = compilation.GetTypeByMetadataName("Microsoft.EntityFrameworkCore.DbSet`1");
+        if (dbSetType is not null && InheritsFrom(methodSymbol.ContainingType, dbSetType))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool InheritsFrom(ITypeSymbol? type, INamedTypeSymbol? baseType)
+    {
+        if (baseType is null) return false;
+
+        while (type != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, baseType))
+            {
+                return true;
+            }
+            type = type.BaseType!;
+        }
+
+        return false;
+    }
+
+    public static bool IsValueObject(ITypeSymbol type) =>
+        type is INamedTypeSymbol symbol && VoFilter.IsTarget(symbol);
+
+    public static bool IsEfQuery(QueryExpressionSyntax queryExpr, SemanticModel semanticModel)
+    {
+        var fromClauseSymbol = semanticModel.GetSymbolInfo(queryExpr.FromClause.Expression).Symbol;
+        ITypeSymbol? fromType = fromClauseSymbol switch
+        {
+            ILocalSymbol local => local.Type,
+            IPropertySymbol property => property.Type,
+            IFieldSymbol field => field.Type,
+            _ => semanticModel.GetTypeInfo(queryExpr.FromClause.Expression).Type
+        };
+
+        if (fromType is null) return false;
+        
+        var iQueryableType = semanticModel.Compilation.GetTypeByMetadataName("System.Linq.IQueryable`1");
+
+        if (iQueryableType is not null && InheritsFrom(fromType, iQueryableType))
+        {
+            return true;
+        }
+
+        var dbSetType = semanticModel.Compilation.GetTypeByMetadataName("Microsoft.EntityFrameworkCore.DbSet`1");
+
+        if (dbSetType is not null && InheritsFrom(fromType, dbSetType))
+        {
+            return true;
+        }
+        return false;
+    }
+}

--- a/tests/AnalyzerTests/DoNotAccessValueInEfCoreAnalyzerTests.cs
+++ b/tests/AnalyzerTests/DoNotAccessValueInEfCoreAnalyzerTests.cs
@@ -1,0 +1,188 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Shared;
+using Vogen;
+using VerifyCS = AnalyzerTests.Verifiers.CSharpAnalyzerVerifier<Vogen.Rules.DoNotAccessValueInEfCoreAnalyzer>;
+
+namespace AnalyzerTests;
+
+public class DoNotAccessValueInEfCoreAnalyzerTests
+{
+    private const string _source =
+        """
+        using System;
+        using System.Collections.Generic;
+        using System.Linq;
+        using Microsoft.EntityFrameworkCore;
+        using Vogen;
+        
+        [assembly: VogenDefaults(conversions: Conversions.EfCoreValueConverter, openApiSchemaCustomizations: OpenApiSchemaCustomizations.Omit)]
+
+        namespace Whatever;
+
+        public class EmployeeEntity
+        {
+            public Id Id { get; set; } = null!;
+            public required Age Age { get; set; }
+        }
+
+        [ValueObject]
+        public partial class Id;
+
+        [ValueObject]
+        public readonly partial struct Age;
+
+        internal class DbContext : Microsoft.EntityFrameworkCore.DbContext
+        {
+            public DbSet<EmployeeEntity> Entities { get; set; } = default!;
+        }
+        """;
+
+    private static readonly Regex _placeholderPattern = new(@"{\|#\d+:", RegexOptions.Compiled);
+
+    [Fact]
+    public async Task NoDiagnosticsForEmptyCode()
+    {
+        var test = @"";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Triggers_when_Value_is_accessed_in_Where()
+    {
+        var source = _source + """
+
+                               public static class Test
+                               {
+                                   public static void FilterItems()
+                                   {
+                                       using var ctx = new DbContext();
+                                       var entities = ctx.Entities.Where(e => {|#0:e.Age.Value|} == 50);
+                                   }
+                               }
+                               """;
+        var sources = await CombineUserAndGeneratedSource(source);
+
+        await Run(
+            sources,
+            WithDiagnostics("VOG039", DiagnosticSeverity.Warning, "Age", 0));
+    }
+    [Fact]
+    public async Task Triggers_when_Value_is_accessed_in_chained_Where()
+    {
+        var source = _source + """
+
+                               public static class Test
+                               {
+                                   public static void FilterItems()
+                                   {
+                                       using var ctx = new DbContext();
+                                       var entities = ctx.Entities.Where(x => true).Where(e => {|#0:e.Age.Value|} == 50);
+                                   }
+                               }
+                               """;
+        var sources = await CombineUserAndGeneratedSource(source);
+
+        await Run(
+            sources,
+            WithDiagnostics("VOG039", DiagnosticSeverity.Warning, "Age", 0));
+    }
+
+    
+
+    [Fact]
+    public async Task Triggers_when_Value_is_accessed_in_QuerySyntax()
+    {
+        var source = _source + """
+
+                               public static class Test
+                               {
+                                   public static void FilterItems()
+                                   {
+                                       using var ctx = new DbContext();
+                                       var entities = from e in ctx.Entities
+                                                      where {|#0:e.Age.Value|} == 50
+                                                      select e;
+                                   }
+                               }
+                               """;
+        var sources = await CombineUserAndGeneratedSource(source);
+
+        await Run(
+            sources,
+            WithDiagnostics("VOG039", DiagnosticSeverity.Warning, "Age", 0));
+    }
+
+    [Fact]
+    public async Task Not_triggered_when_found_in_non_IQueryableOfDbSet()
+    {
+        var source = _source + """
+
+                               public static class Test
+                               {
+                                   public static void FilterItems()
+                                   {
+                                       var employees = new List<EmployeeEntity>();
+                                       var matching = employees.Where(e => e.Age.Value == 50);
+                                   }
+                               }
+                               """;
+        var sources = await CombineUserAndGeneratedSource(source);
+
+        await Run(sources, Enumerable.Empty<DiagnosticResult>());
+    }
+
+    private static IEnumerable<DiagnosticResult> WithDiagnostics(string code,
+        DiagnosticSeverity severity,
+        string arguments,
+        params int[] locations)
+    {
+        foreach (var location in locations)
+        {
+            yield return VerifyCS.Diagnostic(code).WithSeverity(severity).WithLocation(location)
+                .WithArguments(arguments);
+        }
+    }
+
+    private async Task Run(string[] sources, IEnumerable<DiagnosticResult> expected)
+    {
+        var test = new VerifyCS.Test
+        {
+            CompilerDiagnostics = CompilerDiagnostics.Errors,
+            ReferenceAssemblies = References.Net90WithEfCoreAndOurs.Value,
+        };
+
+        foreach (var eachSource in sources)
+        {
+            test.TestState.Sources.Add(eachSource);
+        }
+
+        test.ExpectedDiagnostics.AddRange(expected);
+
+        await test.RunAsync();
+    }
+
+    private static async Task<string[]> CombineUserAndGeneratedSource(string userSource)
+    {
+        PortableExecutableReference peReference = MetadataReference.CreateFromFile(typeof(ValueObjectAttribute).Assembly.Location);
+        var strippedSource = _placeholderPattern.Replace(userSource, string.Empty).Replace("|}", string.Empty);
+
+        (ImmutableArray<Diagnostic> Diagnostics, SyntaxTree[] GeneratedSources) output = await new ProjectBuilder()
+            .WithUserSource(strippedSource)
+            .WithTargetFramework(TargetFramework.Net9_0)
+            .GetGeneratedOutput<ValueObjectGenerator>(ignoreInitialCompilationErrors: true, peReference);
+
+        if (output.Diagnostics.Length > 0)
+        {
+            throw new Xunit.Sdk.XunitException(
+                $"Expected user source to be error and generated code to be free from errors:\nErrors: {string.Join(",", output.Diagnostics.Select(d => d.ToString()))}");
+        }
+
+        return [userSource, .. output.GeneratedSources.Select(o => o.ToString())];
+    }
+}

--- a/tests/AnalyzerTests/DoNotCompareWithPrimitivesInEfCoreAnalyzerTests.cs
+++ b/tests/AnalyzerTests/DoNotCompareWithPrimitivesInEfCoreAnalyzerTests.cs
@@ -99,7 +99,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzerTests
 
             await Run(
                 sources,
-                WithDiagnostics("VOG034", DiagnosticSeverity.Error, "Age", 0));
+                WithDiagnostics("VOG034", DiagnosticSeverity.Warning, "Age", 0));
         }
 
         [Fact]
@@ -122,10 +122,10 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzerTests
 
             await Run(
                 sources,
-                WithDiagnostics("VOG034", DiagnosticSeverity.Error, "Age", 0));
+                WithDiagnostics("VOG034", DiagnosticSeverity.Warning, "Age", 0));
         }
 
-        [Fact(Skip = "It would be nice if this did work, but I couldn't get it working. Please see the thread at https://github.com/SteveDunn/Vogen/issues/684")]
+        [Fact]
         public async Task Triggers_when_found_in_IQueryableOfDbSet_in_separate_expression_twice_removed()
         {
             var source = _source + """
@@ -146,7 +146,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzerTests
 
             await Run(
                 sources,
-                WithDiagnostics("VOG034", DiagnosticSeverity.Error, "Age", 0));
+                WithDiagnostics("VOG034", DiagnosticSeverity.Warning, "Age", 0));
         }
 
         [Fact]
@@ -170,7 +170,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzerTests
 
             await Run(
                 sources,
-                WithDiagnostics("VOG034", DiagnosticSeverity.Error, "Age", 0));
+                WithDiagnostics("VOG034", DiagnosticSeverity.Warning, "Age", 0));
         }
 
         [Fact]
@@ -192,7 +192,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzerTests
 
             await Run(
                 sources,
-                WithDiagnostics("VOG034", DiagnosticSeverity.Error, "Age", 0));
+                WithDiagnostics("VOG034", DiagnosticSeverity.Warning, "Age", 0));
         }
 
         [Fact]
@@ -214,7 +214,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzerTests
 
             await Run(
                 sources,
-                WithDiagnostics("VOG034", DiagnosticSeverity.Error, "Age", 0));
+                WithDiagnostics("VOG034", DiagnosticSeverity.Warning, "Age", 0));
         }
 
         [Fact]
@@ -318,7 +318,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzerTests
 
             await Run(
                 sources,
-                WithDiagnostics("VOG034", DiagnosticSeverity.Error, "Age", 0));
+                WithDiagnostics("VOG034", DiagnosticSeverity.Warning, "Age", 0));
         }
 
         [Fact]
@@ -340,7 +340,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzerTests
 
             await Run(
                 sources,
-                WithDiagnostics("VOG034", DiagnosticSeverity.Error, "Age", 0));
+                WithDiagnostics("VOG034", DiagnosticSeverity.Warning, "Age", 0));
         }
 
         [Fact]
@@ -362,7 +362,7 @@ public class DoNotCompareWithPrimitivesInEfCoreAnalyzerTests
 
             await Run(
                 sources,
-                WithDiagnostics("VOG034", DiagnosticSeverity.Error, "Age", 0));
+                WithDiagnostics("VOG034", DiagnosticSeverity.Warning, "Age", 0));
         }
 
         [Fact]


### PR DESCRIPTION
- Changes the `DoNotCompareWithPrimitivesInEfCoreAnalyzer` from `Error` to `Warning`: IQueryable is not only used in the context of EFCore, but wen cannot really differentiate between an EFCore IQueryable and something else. Thus this should probably be a warning, because false positives are likely.
- Add VOG039 `DoNotAccessValueInEfCoreAnalyzer`: An analyzer that catches the access to `MyVo.Value` inside the expression tree of `IQueryable`s as well as the old query syntax. Accessing those properties inside the context of EFCore queries will crash during runtime, because the query cannot be translated see #699 
- Improved both analyzers to not rely on a hardcoded list of method names, but instead work on `IQueryable` extensions.
- Made both analyzers only run in compilations that include EFCore