### PR TITLE
feat: add stringDefaultComparison for type-level default string comparer

### DIFF
--- a/src/Vogen.SharedTypes/StringComparisonDefault.cs
+++ b/src/Vogen.SharedTypes/StringComparisonDefault.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics;
+// ReSharper disable UnusedMember.Global
+
+namespace Vogen;
+
+public enum StringComparisonDefault
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    Unspecified = -1,
+    Omit = 0,
+    Ordinal = 1,
+    OrdinalIgnoreCase = 2,
+    CurrentCulture = 3,
+    CurrentCultureIgnoreCase = 4,
+    InvariantCulture = 5,
+    InvariantCultureIgnoreCase = 6,
+}

--- a/src/Vogen.SharedTypes/ValueObjectAttribute.cs
+++ b/src/Vogen.SharedTypes/ValueObjectAttribute.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable UnusedParameter.Local
+// ReSharper disable UnusedParameter.Local
 // ReSharper disable NullableWarningSuppressionIsUsed
 // ReSharper disable UnusedType.Global
 
@@ -88,6 +88,78 @@ namespace Vogen
             numericsGeneration)
         {
         }
+
+        /// <summary>
+        /// Configures aspects of this individual value object.
+        /// </summary>
+        /// <param name="conversions">Specifies what conversion code is generated - defaults to <see cref="Conversions.Default"/> which generates type converters and a converter to handle serialization using System.Text.Json</param>
+        /// <param name="throws">Specifies the type of exception thrown when validation fails—defaults to <see cref="ValueObjectValidationException"/>.</param>
+        /// <param name="customizations">Simple customization switches—defaults to <see cref="Customizations.None"/>.</param>
+        /// <param name="deserializationStrictness">Specifies how strict deserialization is, e.g. should your Validate method be called, or should pre-defined instances that otherwise invalid be allowed - defaults to <see cref="DeserializationStrictness.AllowValidAndKnownInstances"/>.</param>
+        /// <param name="debuggerAttributes">Specifies the level that debug attributes are written as some IDEs don't support all of them, e.g., Rider - defaults to <see cref="DebuggerAttributeGeneration.Full"/> which generates DebuggerDisplay and a debugger proxy type for IDEs that support them</param>
+        /// <param name="comparison">Species which comparison code is generated—defaults to <see cref="ComparisonGeneration.UseUnderlying"/> which hoists any IComparable implementations from the primitive.</param>
+        /// <param name="stringComparers">Specifies which string comparison code is generated—defaults to <see cref="StringComparersGeneration.Omit"/> which doesn't generate anything related to string comparison.</param>
+        /// <param name="toPrimitiveCasting">Controls how cast operators are generated for casting from the Value Object to the primitive.
+        /// Options are implicit or explicit or none.  Explicit is preferred over implicit if you really need them, but isn't recommended.
+        /// See <see href="https://github.com/SteveDunn/Vogen/wiki/Casting"/> for more information.</param>
+        /// <param name="fromPrimitiveCasting">Controls how cast operators are generated for casting from the primitive to the Value Object.
+        /// Options are implicit or explicit or none.  Explicit is preferred over implicit if you really need them, but isn't recommended.
+        /// See <see href="https://github.com/SteveDunn/Vogen/wiki/Casting"/> for more information.
+        /// </param>
+        /// <param name="parsableForStrings">Specifies what is generated for IParsable types for strings - defaults to <see cref="ParsableForStrings.GenerateMethodsAndInterface"/>.</param>
+        /// <param name="parsableForPrimitives">Specifies what is generated for Parse and TryParse methods - defaults to <see cref="ParsableForPrimitives.HoistMethodsAndInterfaces"/>.</param>
+        /// <param name="tryFromGeneration">Specifies what to write for TryFrom methods—defaults to <see cref="TryFromGeneration.GenerateBoolAndErrorOrMethods"/>.</param>
+        /// <param name="isInitializedMethodGeneration">Specifies whether to generate an IsInitialized() method - defaults to <see cref="IsInitializedMethodGeneration.Generate"/>.</param>
+        /// <param name="primitiveEqualityGeneration">
+        /// Specifies whether to generate primitive comparison operators, allowing this type to be compared for equality to the primitive.
+        /// Defaults to <see cref="PrimitiveEqualityGeneration.GenerateOperatorsAndMethods"/>
+        /// <example>
+        /// <para>
+        /// var vo = MyInt.From(123);
+        /// </para>
+        /// <para>
+        /// bool same = vo == 123;
+        /// </para>
+        /// </example>
+        /// </param>
+        /// <param name="numericsGeneration">Specifies whether to generate numeric interfaces (<c>INumber&lt;T&gt;</c> or <c>INumberBase&lt;T&gt;</c> depending on the underlying type)—defaults to <see cref="NumericsGeneration.Omit"/>.</param>
+        /// <param name="stringDefaultComparison">Specifies the default <see cref="StringComparisonDefault"/> used for <c>==</c>, <c>Equals</c>, and <c>GetHashCode</c> on string-backed value objects—defaults to <see cref="StringComparisonDefault.Omit"/> which uses the underlying string's default comparison.</param>
+        public ValueObjectAttribute(
+            Conversions conversions = Conversions.Unspecified,
+            Type? throws = null!,
+            Customizations customizations = Customizations.None,
+            DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,
+            DebuggerAttributeGeneration debuggerAttributes = DebuggerAttributeGeneration.Default,
+            ComparisonGeneration comparison = ComparisonGeneration.Default,
+            StringComparersGeneration stringComparers = StringComparersGeneration.Unspecified,
+            CastOperator toPrimitiveCasting = CastOperator.Unspecified,
+            CastOperator fromPrimitiveCasting = CastOperator.Unspecified,
+            ParsableForStrings parsableForStrings = ParsableForStrings.Unspecified,
+            ParsableForPrimitives parsableForPrimitives = ParsableForPrimitives.Unspecified,
+            TryFromGeneration tryFromGeneration = TryFromGeneration.Unspecified,
+            IsInitializedMethodGeneration isInitializedMethodGeneration = IsInitializedMethodGeneration.Unspecified,
+            PrimitiveEqualityGeneration primitiveEqualityGeneration = PrimitiveEqualityGeneration.Unspecified,
+            NumericsGeneration numericsGeneration = NumericsGeneration.Unspecified,
+            StringComparisonDefault stringDefaultComparison = StringComparisonDefault.Unspecified) : base(
+            typeof(T),
+            conversions,
+            throws,
+            customizations,
+            deserializationStrictness,
+            debuggerAttributes,
+            comparison,
+            stringComparers,
+            toPrimitiveCasting,
+            fromPrimitiveCasting,
+            parsableForStrings,
+            parsableForPrimitives,
+            tryFromGeneration,
+            isInitializedMethodGeneration,
+            primitiveEqualityGeneration,
+            numericsGeneration,
+            stringDefaultComparison)
+        {
+        }
     }
 
     /// <summary>
@@ -100,7 +172,7 @@ namespace Vogen
         // keep this signature in-line with `VogenConfiguration`
         // as the syntax/semantics are read in the generator
         // using parameter indexes (i.e. it expected param 0 to be the underlying type etc).
-        
+
         // ReSharper disable once MemberCanBeProtected.Global
         
         /// <summary>
@@ -150,6 +222,62 @@ namespace Vogen
             IsInitializedMethodGeneration isInitializedMethodGeneration = IsInitializedMethodGeneration.Unspecified,
             PrimitiveEqualityGeneration primitiveEqualityGeneration = PrimitiveEqualityGeneration.Unspecified,
             NumericsGeneration numericsGeneration = NumericsGeneration.Unspecified)
+        {
+            // DO NOT ADD PARAMETERS HERE, INSTEAD, CREATE OVERLOADS (at least until a new major version).
+            // This is because some users use reflection to find this attribute, and changing the amount
+            // of parameters is a binary-breaking change. See https://github.com/dotnet/runtime/issues/103722
+            // for more information.
+        }
+
+        /// <summary>
+        /// Configures aspects of this individual value object.
+        /// </summary>
+        /// <param name="underlyingType">The type of the primitive that is being wrapped—defaults to int.</param>
+        /// <param name="conversions">Specifies what conversion code is generated - defaults to <see cref="Conversions.Default"/> which generates type converters and a converter to handle serialization using System.Text.Json</param>
+        /// <param name="throws">Specifies the type of exception thrown when validation fails—defaults to <see cref="ValueObjectValidationException"/>.</param>
+        /// <param name="customizations">Simple customization switches—defaults to <see cref="Customizations.None"/>.</param>
+        /// <param name="deserializationStrictness">Specifies how strict deserialization is, e.g. should your Validate method be called, or should pre-defined instances that otherwise invalid be allowed - defaults to <see cref="DeserializationStrictness.AllowValidAndKnownInstances"/>.</param>
+        /// <param name="debuggerAttributes">Specifies the level that debug attributes are written as some IDEs don't support all of them, e.g., Rider - defaults to <see cref="DebuggerAttributeGeneration.Full"/> which generates DebuggerDisplay and a debugger proxy type for IDEs that support them</param>
+        /// <param name="comparison">Species which comparison code is generated—defaults to <see cref="ComparisonGeneration.UseUnderlying"/> which hoists any IComparable implementations from the primitive.</param>
+        /// <param name="stringComparers">Specifies which string comparison code is generated—defaults to <see cref="StringComparersGeneration.Omit"/> which doesn't generate anything related to string comparison.</param>
+        /// <param name="toPrimitiveCasting">Specifies the type of casting from wrapper to primitive - defaults to <see cref="CastOperator.Explicit"/>.</param>
+        /// <param name="fromPrimitiveCasting">Specifies the type of casting from primitive to wrapper - default to <see cref="CastOperator.Explicit"/>.</param>
+        /// <param name="parsableForStrings">Specifies what is generated for IParsable types for strings - defaults to <see cref="ParsableForStrings.GenerateMethodsAndInterface"/>.</param>
+        /// <param name="parsableForPrimitives">Specifies what is generated for Parse and TryParse methods - defaults to <see cref="ParsableForPrimitives.HoistMethodsAndInterfaces"/>.</param>
+        /// <param name="tryFromGeneration">Specifies what to write for TryFrom methods—defaults to <see cref="TryFromGeneration.GenerateBoolAndErrorOrMethods"/>.</param>
+        /// <param name="isInitializedMethodGeneration">Specifies whether to generate an IsInitialized() method - defaults to <see cref="IsInitializedMethodGeneration.Generate"/>.</param>
+        /// <param name="primitiveEqualityGeneration">
+        /// Specifies whether to generate primitive comparison operators, allowing this type to be compared for equality to the primitive.
+        /// Defaults to <see cref="PrimitiveEqualityGeneration.GenerateOperatorsAndMethods"/>
+        /// <example>
+        /// <para>
+        /// var vo = MyInt.From(123);
+        /// </para>
+        /// <para>
+        /// bool same = vo == 123;
+        /// </para>
+        /// </example>
+        /// </param>
+        /// <param name="numericsGeneration">Specifies whether to generate numeric interfaces (<c>INumber&lt;T&gt;</c> or <c>INumberBase&lt;T&gt;</c> depending on the underlying type)—defaults to <see cref="NumericsGeneration.Omit"/>.</param>
+        /// <param name="stringDefaultComparison">Specifies the default <see cref="StringComparisonDefault"/> used for <c>==</c>, <c>Equals</c>, and <c>GetHashCode</c> on string-backed value objects—defaults to <see cref="StringComparisonDefault.Omit"/> which uses the underlying string's default comparison.</param>
+        public ValueObjectAttribute(
+            Type? underlyingType = null!,
+            Conversions conversions = Conversions.Unspecified,
+            Type? throws = null!,
+            Customizations customizations = Customizations.None,
+            DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,
+            DebuggerAttributeGeneration debuggerAttributes = DebuggerAttributeGeneration.Default,
+            ComparisonGeneration comparison = ComparisonGeneration.Default,
+            StringComparersGeneration stringComparers = StringComparersGeneration.Unspecified,
+            CastOperator toPrimitiveCasting = CastOperator.Unspecified,
+            CastOperator fromPrimitiveCasting = CastOperator.Unspecified,
+            ParsableForStrings parsableForStrings = ParsableForStrings.Unspecified,
+            ParsableForPrimitives parsableForPrimitives = ParsableForPrimitives.Unspecified,
+            TryFromGeneration tryFromGeneration = TryFromGeneration.Unspecified,
+            IsInitializedMethodGeneration isInitializedMethodGeneration = IsInitializedMethodGeneration.Unspecified,
+            PrimitiveEqualityGeneration primitiveEqualityGeneration = PrimitiveEqualityGeneration.Unspecified,
+            NumericsGeneration numericsGeneration = NumericsGeneration.Unspecified,
+            StringComparisonDefault stringDefaultComparison = StringComparisonDefault.Unspecified)
         {
             // DO NOT ADD PARAMETERS HERE, INSTEAD, CREATE OVERLOADS (at least until a new major version).
             // This is because some users use reflection to find this attribute, and changing the amount

--- a/src/Vogen.SharedTypes/ValueObjectAttribute.cs
+++ b/src/Vogen.SharedTypes/ValueObjectAttribute.cs
@@ -125,22 +125,22 @@ namespace Vogen
         /// <param name="numericsGeneration">Specifies whether to generate numeric interfaces (<c>INumber&lt;T&gt;</c> or <c>INumberBase&lt;T&gt;</c> depending on the underlying type)—defaults to <see cref="NumericsGeneration.Omit"/>.</param>
         /// <param name="stringDefaultComparison">Specifies the default <see cref="StringComparisonDefault"/> used for <c>==</c>, <c>Equals</c>, and <c>GetHashCode</c> on string-backed value objects—defaults to <see cref="StringComparisonDefault.Omit"/> which uses the underlying string's default comparison.</param>
         public ValueObjectAttribute(
-            Conversions conversions = Conversions.Unspecified,
-            Type? throws = null!,
-            Customizations customizations = Customizations.None,
-            DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,
-            DebuggerAttributeGeneration debuggerAttributes = DebuggerAttributeGeneration.Default,
-            ComparisonGeneration comparison = ComparisonGeneration.Default,
-            StringComparersGeneration stringComparers = StringComparersGeneration.Unspecified,
-            CastOperator toPrimitiveCasting = CastOperator.Unspecified,
-            CastOperator fromPrimitiveCasting = CastOperator.Unspecified,
-            ParsableForStrings parsableForStrings = ParsableForStrings.Unspecified,
-            ParsableForPrimitives parsableForPrimitives = ParsableForPrimitives.Unspecified,
-            TryFromGeneration tryFromGeneration = TryFromGeneration.Unspecified,
-            IsInitializedMethodGeneration isInitializedMethodGeneration = IsInitializedMethodGeneration.Unspecified,
-            PrimitiveEqualityGeneration primitiveEqualityGeneration = PrimitiveEqualityGeneration.Unspecified,
-            NumericsGeneration numericsGeneration = NumericsGeneration.Unspecified,
-            StringComparisonDefault stringDefaultComparison = StringComparisonDefault.Unspecified) : base(
+            Conversions conversions,
+            Type? throws,
+            Customizations customizations,
+            DeserializationStrictness deserializationStrictness,
+            DebuggerAttributeGeneration debuggerAttributes,
+            ComparisonGeneration comparison,
+            StringComparersGeneration stringComparers,
+            CastOperator toPrimitiveCasting,
+            CastOperator fromPrimitiveCasting,
+            ParsableForStrings parsableForStrings,
+            ParsableForPrimitives parsableForPrimitives,
+            TryFromGeneration tryFromGeneration,
+            IsInitializedMethodGeneration isInitializedMethodGeneration,
+            PrimitiveEqualityGeneration primitiveEqualityGeneration,
+            NumericsGeneration numericsGeneration,
+            StringComparisonDefault stringDefaultComparison) : base(
             typeof(T),
             conversions,
             throws,
@@ -174,7 +174,7 @@ namespace Vogen
         // using parameter indexes (i.e. it expected param 0 to be the underlying type etc).
 
         // ReSharper disable once MemberCanBeProtected.Global
-        
+
         /// <summary>
         /// Configures aspects of this individual value object.
         /// </summary>
@@ -261,23 +261,23 @@ namespace Vogen
         /// <param name="numericsGeneration">Specifies whether to generate numeric interfaces (<c>INumber&lt;T&gt;</c> or <c>INumberBase&lt;T&gt;</c> depending on the underlying type)—defaults to <see cref="NumericsGeneration.Omit"/>.</param>
         /// <param name="stringDefaultComparison">Specifies the default <see cref="StringComparisonDefault"/> used for <c>==</c>, <c>Equals</c>, and <c>GetHashCode</c> on string-backed value objects—defaults to <see cref="StringComparisonDefault.Omit"/> which uses the underlying string's default comparison.</param>
         public ValueObjectAttribute(
-            Type? underlyingType = null!,
-            Conversions conversions = Conversions.Unspecified,
-            Type? throws = null!,
-            Customizations customizations = Customizations.None,
-            DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,
-            DebuggerAttributeGeneration debuggerAttributes = DebuggerAttributeGeneration.Default,
-            ComparisonGeneration comparison = ComparisonGeneration.Default,
-            StringComparersGeneration stringComparers = StringComparersGeneration.Unspecified,
-            CastOperator toPrimitiveCasting = CastOperator.Unspecified,
-            CastOperator fromPrimitiveCasting = CastOperator.Unspecified,
-            ParsableForStrings parsableForStrings = ParsableForStrings.Unspecified,
-            ParsableForPrimitives parsableForPrimitives = ParsableForPrimitives.Unspecified,
-            TryFromGeneration tryFromGeneration = TryFromGeneration.Unspecified,
-            IsInitializedMethodGeneration isInitializedMethodGeneration = IsInitializedMethodGeneration.Unspecified,
-            PrimitiveEqualityGeneration primitiveEqualityGeneration = PrimitiveEqualityGeneration.Unspecified,
-            NumericsGeneration numericsGeneration = NumericsGeneration.Unspecified,
-            StringComparisonDefault stringDefaultComparison = StringComparisonDefault.Unspecified)
+            Type? underlyingType,
+            Conversions conversions,
+            Type? throws,
+            Customizations customizations,
+            DeserializationStrictness deserializationStrictness,
+            DebuggerAttributeGeneration debuggerAttributes,
+            ComparisonGeneration comparison,
+            StringComparersGeneration stringComparers,
+            CastOperator toPrimitiveCasting,
+            CastOperator fromPrimitiveCasting,
+            ParsableForStrings parsableForStrings,
+            ParsableForPrimitives parsableForPrimitives,
+            TryFromGeneration tryFromGeneration,
+            IsInitializedMethodGeneration isInitializedMethodGeneration,
+            PrimitiveEqualityGeneration primitiveEqualityGeneration,
+            NumericsGeneration numericsGeneration,
+            StringComparisonDefault stringDefaultComparison)
         {
             // DO NOT ADD PARAMETERS HERE, INSTEAD, CREATE OVERLOADS (at least until a new major version).
             // This is because some users use reflection to find this attribute, and changing the amount

--- a/src/Vogen.SharedTypes/VogenDefaultsAttribute.cs
+++ b/src/Vogen.SharedTypes/VogenDefaultsAttribute.cs
@@ -76,4 +76,69 @@ public class VogenDefaultsAttribute : Attribute
         NumericsGeneration numericsGeneration = NumericsGeneration.Unspecified)
     {
     }
+
+    /// <summary>
+    /// Creates a new instance of a type that represents the default
+    /// values used for value object generation.
+    /// </summary>
+    /// <param name="underlyingType">The type of the primitive that is being wrapped—defaults to int.</param>
+    /// <param name="conversions">Specifies what conversion code is generated - defaults to <see cref="Conversions.Default"/> which generates type converters and a converter to handle serialization using System.Text.Json</param>
+    /// <param name="throws">Specifies the type of exception thrown when validation fails—defaults to <see cref="ValueObjectValidationException"/>.</param>
+    /// <param name="customizations">Simple customization switches—defaults to <see cref="Customizations.None"/>.</param>
+    /// <param name="deserializationStrictness">Specifies how strict deserialization is, e.g. should your Validate method be called, or should pre-defined instances that otherwise invalid be allowed - defaults to <see cref="DeserializationStrictness.AllowValidAndKnownInstances"/>.</param>
+    /// <param name="debuggerAttributes">Specifies the level that debug attributes are written as some IDEs don't support all of them, e.g., Rider - defaults to <see cref="DebuggerAttributeGeneration.Full"/> which generates DebuggerDisplay and a debugger proxy type for IDEs that support them</param>
+    /// <param name="toPrimitiveCasting">Controls how cast operators are generated for casting from the Value Object to the primitive.
+    /// Options are implicit or explicit or none.  Explicit is preferred over implicit if you really need them, but isn't recommended.
+    /// See <see href="https://github.com/SteveDunn/Vogen/wiki/Casting"/> for more information.</param>
+    /// <param name="fromPrimitiveCasting">Controls how cast operators are generated for casting from the primitive to the Value Object.
+    /// Options are implicit or explicit or none.  Explicit is preferred over implicit if you really need them, but isn't recommended.
+    /// See &lt;see href="https://github.com/SteveDunn/Vogen/wiki/Casting"/&gt; for more information.</param>
+    /// <param name="disableStackTraceRecordingInDebug">disables stack trace recording; in Debug builds, a stack trace is recorded and is
+    /// thrown in the exception when something is created in an uninitialized state, e.g. after deserialization</param>
+    /// <param name="parsableForStrings">Specifies what is generated for IParsable types for strings - defaults to <see cref="ParsableForStrings.GenerateMethodsAndInterface"/>.</param>
+    /// <param name="parsableForPrimitives">Specifies what is generated for Parse and TryParse methods - defaults to <see cref="ParsableForPrimitives.HoistMethodsAndInterfaces"/>.</param>
+    /// <param name="tryFromGeneration">Specifies what to write for TryFrom methods—defaults to <see cref="TryFromGeneration.GenerateBoolAndErrorOrMethods"/>.</param>
+    /// <param name="isInitializedMethodGeneration">Specifies whether to generate an IsInitialized() method - defaults to <see cref="IsInitializedMethodGeneration.Generate"/>.</param>
+    /// <param name="primitiveEqualityGeneration">
+    /// Specifies whether to generate primitive comparison operators, allowing this type to be compared for equality to the primitive.
+    /// Defaults to <see cref="PrimitiveEqualityGeneration.GenerateOperatorsAndMethods"/>
+    /// <example>
+    /// <para>
+    /// var vo = MyInt.From(123);
+    /// </para>
+    /// <para>
+    /// bool same = vo == 123;
+    /// </para>
+    /// </example>
+    /// </param>
+    /// <param name="systemTextJsonConverterFactoryGeneration">Controls the generation of the type factory for System.Text.Json.</param>
+    /// <param name="staticAbstractsGeneration">Controls the generation of static abstract interfaces.</param>
+    /// <param name="openApiSchemaCustomizations">Controls the generation of a Swashbuckle schema filter for OpenAPI.</param>
+    /// <param name="explicitlySpecifyTypeInValueObject">Every ValueObject attribute must explicitly specify the type of the primitive.</param>
+    /// <param name="numericsGeneration">Specifies whether to generate numeric interfaces (<c>INumber&lt;T&gt;</c> or <c>INumberBase&lt;T&gt;</c> depending on the underlying type)—defaults to <see cref="NumericsGeneration.Omit"/>.</param>
+    /// <param name="stringDefaultComparison">Specifies the default <see cref="StringComparisonDefault"/> used for <c>==</c>, <c>Equals</c>, and <c>GetHashCode</c> on string-backed value objects—defaults to <see cref="StringComparisonDefault.Omit"/> which uses the underlying string's default comparison.</param>
+    public VogenDefaultsAttribute(
+        Type? underlyingType = null,
+        Conversions conversions = Conversions.Unspecified,
+        Type? throws = null,
+        Customizations customizations = Customizations.None,
+        DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,
+        DebuggerAttributeGeneration debuggerAttributes = DebuggerAttributeGeneration.Default,
+        CastOperator toPrimitiveCasting = CastOperator.Explicit,
+        CastOperator fromPrimitiveCasting = CastOperator.Explicit,
+        bool disableStackTraceRecordingInDebug = false,
+        ParsableForStrings parsableForStrings = ParsableForStrings.GenerateMethodsAndInterface,
+        ParsableForPrimitives parsableForPrimitives = ParsableForPrimitives.HoistMethodsAndInterfaces,
+        TryFromGeneration tryFromGeneration = TryFromGeneration.Unspecified,
+        IsInitializedMethodGeneration isInitializedMethodGeneration = IsInitializedMethodGeneration.Unspecified,
+        SystemTextJsonConverterFactoryGeneration systemTextJsonConverterFactoryGeneration =
+            SystemTextJsonConverterFactoryGeneration.Unspecified,
+        StaticAbstractsGeneration staticAbstractsGeneration = StaticAbstractsGeneration.Unspecified,
+        OpenApiSchemaCustomizations openApiSchemaCustomizations = OpenApiSchemaCustomizations.Unspecified,
+        bool explicitlySpecifyTypeInValueObject = false,
+        PrimitiveEqualityGeneration primitiveEqualityGeneration = PrimitiveEqualityGeneration.Unspecified,
+        NumericsGeneration numericsGeneration = NumericsGeneration.Unspecified,
+        StringComparisonDefault stringDefaultComparison = StringComparisonDefault.Unspecified)
+    {
+    }
 }

--- a/src/Vogen.SharedTypes/VogenDefaultsAttribute.cs
+++ b/src/Vogen.SharedTypes/VogenDefaultsAttribute.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable MemberInitializerValueIgnored
+// ReSharper disable MemberInitializerValueIgnored
 // ReSharper disable UnusedType.Global
 
 // ReSharper disable UnusedParameter.Local
@@ -118,27 +118,26 @@ public class VogenDefaultsAttribute : Attribute
     /// <param name="numericsGeneration">Specifies whether to generate numeric interfaces (<c>INumber&lt;T&gt;</c> or <c>INumberBase&lt;T&gt;</c> depending on the underlying type)—defaults to <see cref="NumericsGeneration.Omit"/>.</param>
     /// <param name="stringDefaultComparison">Specifies the default <see cref="StringComparisonDefault"/> used for <c>==</c>, <c>Equals</c>, and <c>GetHashCode</c> on string-backed value objects—defaults to <see cref="StringComparisonDefault.Omit"/> which uses the underlying string's default comparison.</param>
     public VogenDefaultsAttribute(
-        Type? underlyingType = null,
-        Conversions conversions = Conversions.Unspecified,
-        Type? throws = null,
-        Customizations customizations = Customizations.None,
-        DeserializationStrictness deserializationStrictness = DeserializationStrictness.AllowValidAndKnownInstances,
-        DebuggerAttributeGeneration debuggerAttributes = DebuggerAttributeGeneration.Default,
-        CastOperator toPrimitiveCasting = CastOperator.Explicit,
-        CastOperator fromPrimitiveCasting = CastOperator.Explicit,
-        bool disableStackTraceRecordingInDebug = false,
-        ParsableForStrings parsableForStrings = ParsableForStrings.GenerateMethodsAndInterface,
-        ParsableForPrimitives parsableForPrimitives = ParsableForPrimitives.HoistMethodsAndInterfaces,
-        TryFromGeneration tryFromGeneration = TryFromGeneration.Unspecified,
-        IsInitializedMethodGeneration isInitializedMethodGeneration = IsInitializedMethodGeneration.Unspecified,
-        SystemTextJsonConverterFactoryGeneration systemTextJsonConverterFactoryGeneration =
-            SystemTextJsonConverterFactoryGeneration.Unspecified,
-        StaticAbstractsGeneration staticAbstractsGeneration = StaticAbstractsGeneration.Unspecified,
-        OpenApiSchemaCustomizations openApiSchemaCustomizations = OpenApiSchemaCustomizations.Unspecified,
-        bool explicitlySpecifyTypeInValueObject = false,
-        PrimitiveEqualityGeneration primitiveEqualityGeneration = PrimitiveEqualityGeneration.Unspecified,
-        NumericsGeneration numericsGeneration = NumericsGeneration.Unspecified,
-        StringComparisonDefault stringDefaultComparison = StringComparisonDefault.Unspecified)
+        Type? underlyingType,
+        Conversions conversions,
+        Type? throws,
+        Customizations customizations,
+        DeserializationStrictness deserializationStrictness,
+        DebuggerAttributeGeneration debuggerAttributes,
+        CastOperator toPrimitiveCasting,
+        CastOperator fromPrimitiveCasting,
+        bool disableStackTraceRecordingInDebug,
+        ParsableForStrings parsableForStrings,
+        ParsableForPrimitives parsableForPrimitives,
+        TryFromGeneration tryFromGeneration,
+        IsInitializedMethodGeneration isInitializedMethodGeneration,
+        SystemTextJsonConverterFactoryGeneration systemTextJsonConverterFactoryGeneration,
+        StaticAbstractsGeneration staticAbstractsGeneration,
+        OpenApiSchemaCustomizations openApiSchemaCustomizations,
+        bool explicitlySpecifyTypeInValueObject,
+        PrimitiveEqualityGeneration primitiveEqualityGeneration,
+        NumericsGeneration numericsGeneration,
+        StringComparisonDefault stringDefaultComparison)
     {
     }
 }

--- a/src/Vogen/BuildConfigurationFromAttributes.cs
+++ b/src/Vogen/BuildConfigurationFromAttributes.cs
@@ -38,6 +38,7 @@ internal class BuildConfigurationFromAttributes
     private bool _primitiveTypeMustBeExplicit;
     private PrimitiveEqualityGeneration _primitiveEqualityGeneration;
     private NumericsGeneration _numericsGeneration;
+    private StringComparisonDefault _stringDefaultComparison;
 
     private BuildConfigurationFromAttributes(AttributeData att)
     {
@@ -64,6 +65,7 @@ internal class BuildConfigurationFromAttributes
         _primitiveTypeMustBeExplicit = false;
         _primitiveEqualityGeneration = PrimitiveEqualityGeneration.Unspecified;
         _numericsGeneration = NumericsGeneration.Unspecified;
+        _stringDefaultComparison = StringComparisonDefault.Unspecified;
 
         _diagnostics = new List<Diagnostic>();
 
@@ -127,7 +129,8 @@ internal class BuildConfigurationFromAttributes
                 OpenApiSchemaCustomizations: _openApiSchemaCustomizations,
                 ExplicitlySpecifyTypeInValueObject: _primitiveTypeMustBeExplicit,
                 PrimitiveEqualityGeneration: _primitiveEqualityGeneration,
-                NumericsGeneration: _numericsGeneration),
+                NumericsGeneration: _numericsGeneration,
+                StringDefaultComparison: _stringDefaultComparison),
             diagnostics: _diagnostics);
     }
 
@@ -194,6 +197,14 @@ internal class BuildConfigurationFromAttributes
         {
             _diagnostics.Add(DiagnosticsCatalogue.InvalidDeserializationStrictness(syntaxLocation));
         }
+
+        bool hasActiveDefaultComparison = _stringDefaultComparison is not StringComparisonDefault.Unspecified
+            and not StringComparisonDefault.Omit;
+
+        if (hasActiveDefaultComparison && _stringComparers == StringComparersGeneration.Omit)
+        {
+            _diagnostics.Add(DiagnosticsCatalogue.StringDefaultComparisonConflictsWithStringComparersOmit(syntaxLocation));
+        }
     }
 
     // populates all args - it doesn't expect the underlying type argument as that is:
@@ -202,7 +213,7 @@ internal class BuildConfigurationFromAttributes
     // ReSharper disable once CognitiveComplexity
     private void PopulateFromVogenDefaultsAttributeArgs(ImmutableArray<TypedConstant> argsExcludingUnderlyingType)
     {
-        if (argsExcludingUnderlyingType.Length > 18)
+        if (argsExcludingUnderlyingType.Length > 19)
         {
             throw new InvalidOperationException("Too many arguments for the attribute.");
         }
@@ -214,6 +225,11 @@ internal class BuildConfigurationFromAttributes
             if (v is null)
             {
                 continue;
+            }
+
+            if (i == 18)
+            {
+                _stringDefaultComparison = (StringComparisonDefault) v;
             }
 
             if (i == 17)
@@ -313,7 +329,7 @@ internal class BuildConfigurationFromAttributes
     // ReSharper disable once CognitiveComplexity
     private void PopulateFromValueObjectAttributeArgs(ImmutableArray<TypedConstant> args)
     {
-        if (args.Length > 15)
+        if (args.Length > 16)
         {
             throw new InvalidOperationException("Too many arguments for the attribute.");
         }
@@ -325,6 +341,11 @@ internal class BuildConfigurationFromAttributes
             if (v is null)
             {
                 continue;
+            }
+
+            if (i == 15)
+            {
+                _stringDefaultComparison = (StringComparisonDefault) v;
             }
 
             if (i == 14)

--- a/src/Vogen/BuildConfigurationFromAttributes.cs
+++ b/src/Vogen/BuildConfigurationFromAttributes.cs
@@ -198,13 +198,6 @@ internal class BuildConfigurationFromAttributes
             _diagnostics.Add(DiagnosticsCatalogue.InvalidDeserializationStrictness(syntaxLocation));
         }
 
-        bool hasActiveDefaultComparison = _stringDefaultComparison is not StringComparisonDefault.Unspecified
-            and not StringComparisonDefault.Omit;
-
-        if (hasActiveDefaultComparison && _stringComparers == StringComparersGeneration.Omit)
-        {
-            _diagnostics.Add(DiagnosticsCatalogue.StringDefaultComparisonConflictsWithStringComparersOmit(syntaxLocation));
-        }
     }
 
     // populates all args - it doesn't expect the underlying type argument as that is:

--- a/src/Vogen/BuildWorkItems.cs
+++ b/src/Vogen/BuildWorkItems.cs
@@ -99,6 +99,14 @@ internal static class BuildWorkItems
             }
         }
 
+        bool hasActiveDefaultComparison = config.StringDefaultComparison is not StringComparisonDefault.Unspecified
+            and not StringComparisonDefault.Omit;
+
+        if (hasActiveDefaultComparison && underlyingType.SpecialType != Microsoft.CodeAnalysis.SpecialType.System_String)
+        {
+            context.ReportDiagnostic(DiagnosticsCatalogue.StringDefaultComparisonNotApplicable(voSymbolInformation, underlyingType));
+        }
+
         IEnumerable<InstanceProperties> instanceProperties =
             TryBuildInstanceProperties(allAttributes, voSymbolInformation, context, underlyingType, vogenKnownSymbols).ToList();
 

--- a/src/Vogen/CombineConfigurations.cs
+++ b/src/Vogen/CombineConfigurations.cs
@@ -158,6 +158,14 @@ public static class CombineConfigurations
             (var local, _) => local,
         };
 
+        StringComparisonDefault stringDefaultComparison = (localValues.StringDefaultComparison, globalValues?.StringDefaultComparison) switch
+        {
+            (StringComparisonDefault.Unspecified, null) => VogenConfiguration.DefaultInstance.StringDefaultComparison,
+            (StringComparisonDefault.Unspecified, StringComparisonDefault.Unspecified) => VogenConfiguration.DefaultInstance.StringDefaultComparison,
+            (StringComparisonDefault.Unspecified, var global) => global.Value,
+            (var local, _) => local,
+        };
+
         var validationExceptionType = localValues.ValidationExceptionType ?? 
                                       globalValues?.ValidationExceptionType ?? 
                                       VogenConfiguration.DefaultInstance.ValidationExceptionType;
@@ -193,7 +201,8 @@ public static class CombineConfigurations
             OpenApiSchemaCustomizations: openApiSchemaCustomizations,
             ExplicitlySpecifyTypeInValueObject: primitiveTypeMustBeExplicit,
             PrimitiveEqualityGeneration: primitiveEqualityGeneration,
-            NumericsGeneration: numericsGeneration);
+            NumericsGeneration: numericsGeneration,
+            StringDefaultComparison: stringDefaultComparison);
     }
  
     /// If we don't have a global attribute, just use the default configuration as there

--- a/src/Vogen/Diagnostics/DiagnosticsCatalogue.cs
+++ b/src/Vogen/Diagnostics/DiagnosticsCatalogue.cs
@@ -141,11 +141,6 @@ internal static class DiagnosticsCatalogue
         "'{0}' has StringDefaultComparison set, but the underlying type '{1}' is not a string. StringDefaultComparison only applies to string-backed value objects.",
         DiagnosticSeverity.Warning);
 
-    private static readonly DiagnosticDescriptor _stringDefaultComparisonConflictsWithStringComparersOmit = CreateDescriptor(
-        RuleIdentifiers.StringDefaultComparisonConflictsWithStringComparersOmit,
-        "StringDefaultComparison conflicts with StringComparersGeneration.Omit",
-        "Cannot set stringComparers to Omit when stringDefaultComparison is specified, as the Comparers class must be generated to support the default comparison.");
-
     public static Diagnostic TypeCannotBeNested(INamedTypeSymbol typeModel, INamedTypeSymbol container) => 
         Create(_typeCannotBeNested, typeModel.Locations, typeModel.Name, container.Name);
 
@@ -227,9 +222,6 @@ internal static class DiagnosticsCatalogue
 
     public static Diagnostic StringDefaultComparisonNotApplicable(INamedTypeSymbol voSymbol, ITypeSymbol underlyingType) =>
         Create(_stringDefaultComparisonNotApplicable, voSymbol.Locations, voSymbol.Name, underlyingType.Name);
-
-    public static Diagnostic StringDefaultComparisonConflictsWithStringComparersOmit(Location location) =>
-        Diagnostic.Create(_stringDefaultComparisonConflictsWithStringComparersOmit, location);
 
     private static DiagnosticDescriptor CreateDescriptor(string code, string title, string messageFormat, DiagnosticSeverity severity = DiagnosticSeverity.Error)
     {

--- a/src/Vogen/Diagnostics/DiagnosticsCatalogue.cs
+++ b/src/Vogen/Diagnostics/DiagnosticsCatalogue.cs
@@ -135,6 +135,17 @@ internal static class DiagnosticsCatalogue
         "'{0}' has NumericsGeneration.Generate set, but the underlying type '{1}' does not implement INumberBase<T>. No numeric interface will be generated.",
         DiagnosticSeverity.Warning);
 
+    private static readonly DiagnosticDescriptor _stringDefaultComparisonNotApplicable = CreateDescriptor(
+        RuleIdentifiers.StringDefaultComparisonNotApplicable,
+        "StringDefaultComparison has no effect",
+        "'{0}' has StringDefaultComparison set, but the underlying type '{1}' is not a string. StringDefaultComparison only applies to string-backed value objects.",
+        DiagnosticSeverity.Warning);
+
+    private static readonly DiagnosticDescriptor _stringDefaultComparisonConflictsWithStringComparersOmit = CreateDescriptor(
+        RuleIdentifiers.StringDefaultComparisonConflictsWithStringComparersOmit,
+        "StringDefaultComparison conflicts with StringComparersGeneration.Omit",
+        "Cannot set stringComparers to Omit when stringDefaultComparison is specified, as the Comparers class must be generated to support the default comparison.");
+
     public static Diagnostic TypeCannotBeNested(INamedTypeSymbol typeModel, INamedTypeSymbol container) => 
         Create(_typeCannotBeNested, typeModel.Locations, typeModel.Name, container.Name);
 
@@ -213,6 +224,12 @@ internal static class DiagnosticsCatalogue
 
     public static Diagnostic NumericsGenerationNotApplicable(INamedTypeSymbol voSymbol, ITypeSymbol underlyingType) =>
         Create(_numericsGenerationNotApplicable, voSymbol.Locations, voSymbol.Name, underlyingType.Name);
+
+    public static Diagnostic StringDefaultComparisonNotApplicable(INamedTypeSymbol voSymbol, ITypeSymbol underlyingType) =>
+        Create(_stringDefaultComparisonNotApplicable, voSymbol.Locations, voSymbol.Name, underlyingType.Name);
+
+    public static Diagnostic StringDefaultComparisonConflictsWithStringComparersOmit(Location location) =>
+        Diagnostic.Create(_stringDefaultComparisonConflictsWithStringComparersOmit, location);
 
     private static DiagnosticDescriptor CreateDescriptor(string code, string title, string messageFormat, DiagnosticSeverity severity = DiagnosticSeverity.Error)
     {

--- a/src/Vogen/Diagnostics/RuleIdentifiers.cs
+++ b/src/Vogen/Diagnostics/RuleIdentifiers.cs
@@ -46,5 +46,4 @@ public static class RuleIdentifiers
     public const string NumericsGenerationNotApplicable = "VOG037";
     public const string PropertyOfValueObjectShouldBeInitialized = "VOG038";
     public const string StringDefaultComparisonNotApplicable = "VOG039";
-    public const string StringDefaultComparisonConflictsWithStringComparersOmit = "VOG040";
 }

--- a/src/Vogen/Diagnostics/RuleIdentifiers.cs
+++ b/src/Vogen/Diagnostics/RuleIdentifiers.cs
@@ -45,4 +45,6 @@ public static class RuleIdentifiers
     public const string BothImplicitAndExplicitCastsSpecified = "VOG036";
     public const string NumericsGenerationNotApplicable = "VOG037";
     public const string PropertyOfValueObjectShouldBeInitialized = "VOG038";
+    public const string StringDefaultComparisonNotApplicable = "VOG039";
+    public const string StringDefaultComparisonConflictsWithStringComparersOmit = "VOG040";
 }

--- a/src/Vogen/GenerateCodeForEqualsMethodsAndOperators.cs
+++ b/src/Vogen/GenerateCodeForEqualsMethodsAndOperators.cs
@@ -13,7 +13,11 @@ public static class GenerateCodeForEqualsMethodsAndOperators
         
         string virtualKeyword = item is { IsRecordClass: true, IsSealed: false } ? "virtual " : " ";
 
-        var ret = item.UserProvidedOverloads.EqualsForWrapper.WasProvided ? string.Empty : 
+        string classEqualityExpr = item.IsUnderlyingAString && item.Config.GetStringDefaultComparerExpression() is { } classComparer
+            ? $"{classComparer}.Equals(Value, other.Value)"
+            : $"global::System.Collections.Generic.EqualityComparer<{item.UnderlyingTypeFullNameWithGlobalAlias}>.Default.Equals(Value, other.Value)";
+
+        var ret = item.UserProvidedOverloads.EqualsForWrapper.WasProvided ? string.Empty :
 $$"""
 
             public {{virtualKeyword}}global::System.Boolean Equals({{className}}{{wrapperQ}} other)
@@ -32,7 +36,7 @@ $$"""
                   return true;
               }
 
-              return GetType() == other.GetType() && {{$"global::System.Collections.Generic.EqualityComparer<{item.UnderlyingTypeFullNameWithGlobalAlias}>.Default.Equals(Value, other.Value)"}};
+              return GetType() == other.GetType() && {{classEqualityExpr}};
             }
 """;
 
@@ -65,6 +69,10 @@ $$"""
     {
         var structName = tds.Identifier;
 
+        string structEqualityExpr = item.IsUnderlyingAString && item.Config.GetStringDefaultComparerExpression() is { } structComparer
+            ? $"{structComparer}.Equals(Value, other.Value)"
+            : $"global::System.Collections.Generic.EqualityComparer<{item.UnderlyingTypeFullNameWithGlobalAlias}>.Default.Equals(Value, other.Value)";
+
         var ret = item.UserProvidedOverloads.EqualsForWrapper.WasProvided ? string.Empty :
 $$"""
             public readonly global::System.Boolean Equals({{structName}} other)
@@ -73,7 +81,7 @@ $$"""
               // We treat anything uninitialized as not equal to anything, even other uninitialized instances of this type.
               if(!IsInitialized() || !other.IsInitialized()) return false;
 
-              return {{$"global::System.Collections.Generic.EqualityComparer<{item.UnderlyingTypeFullNameWithGlobalAlias}>.Default.Equals(Value, other.Value)"}};
+              return {{structEqualityExpr}};
             }
   """;
 
@@ -118,12 +126,16 @@ $$"""
 
         string readonlyOrEmpty = isReadOnly ? " readonly" : string.Empty;
 
+        string primitiveEqualityBody = isString && item.Config.GetStringDefaultComparerExpression() is { } primComparer
+            ? $"return {primComparer}.Equals(Value, primitive);"
+            : "return Value.Equals(primitive);";
+
         string output = item.UserProvidedOverloads.EqualsForUnderlying.WasProvided ? string.Empty :
 $$"""
 
             public{{readonlyOrEmpty}} global::System.Boolean Equals({{item.UnderlyingTypeFullNameWithGlobalAlias}}{{underlyingQ}} primitive)
             {
-              return Value.Equals(primitive);
+              {{primitiveEqualityBody}}
             }
 
 """;
@@ -152,11 +164,23 @@ $$"""
 
         string w = item.Nullable.QuestionMarkForWrapper;
         string u = item.Nullable.QuestionMarkForUnderlying;
-        
+
+        if (item.IsUnderlyingAString && item.Config.GetStringDefaultComparerExpression() is { } opComparer)
+        {
+            return $"""
+
+                        public static global::System.Boolean operator ==({typeName}{w} left, {itemUnderlyingType}{u} right) => {opComparer}.Equals(left{w}.Value, right);
+                        public static global::System.Boolean operator ==({itemUnderlyingType}{u} left, {typeName}{w} right) => {opComparer}.Equals(left, right{w}.Value);
+
+                        public static global::System.Boolean operator !=({itemUnderlyingType}{u} left, {typeName}{w} right) => !(left == right);
+                        public static global::System.Boolean operator !=({typeName}{w} left, {itemUnderlyingType}{u} right) => !(left == right);
+                    """;
+        }
+
         string wDefaultToFalse = item.Nullable.IsEnabled && item.IsTheWrapperAReferenceType ? "?? false" : string.Empty;
 
         return $"""
-                
+
                     public static global::System.Boolean operator ==({typeName}{w} left, {itemUnderlyingType}{u} right) => left{w}.Value.Equals(right) {wDefaultToFalse};
                     public static global::System.Boolean operator ==({itemUnderlyingType}{u} left, {typeName}{w} right) => right{w}.Value.Equals(left) {wDefaultToFalse};
 

--- a/src/Vogen/GenerateCodeForHashCodes.cs
+++ b/src/Vogen/GenerateCodeForHashCodes.cs
@@ -16,13 +16,15 @@ public static class GenerateCodeForHashCodes
         // When the underlying type is a nullable value type (e.g. ushort?), EqualityComparer<T>.Default.GetHashCode
         // has [DisallowNull] on its parameter in .NET 10+, causing CS8607. Use null-safe approach instead.
         // Wrap the expression in parentheses to ensure correct precedence with the ^ operator.
-        string hashCodeExpression = item.UnderlyingType.IsNullableValueType()
-            ? "(Value is null ? 0 : Value.GetHashCode())"
-            : $"global::System.Collections.Generic.EqualityComparer<{itemUnderlyingType}>.Default.GetHashCode(Value)";
+        string hashCodeExpression = item.IsUnderlyingAString && item.Config.GetStringDefaultComparerExpression() is { } classHashComparer
+            ? $"{classHashComparer}.GetHashCode(Value)"
+            : item.UnderlyingType.IsNullableValueType()
+                ? "(Value is null ? 0 : Value.GetHashCode())"
+                : $"global::System.Collections.Generic.EqualityComparer<{itemUnderlyingType}>.Default.GetHashCode(Value)";
 
         return
             $$"""
-              
+
                         public override global::System.Int32 GetHashCode()
                         {
                           unchecked // Overflow is fine, just wrap
@@ -47,13 +49,15 @@ public static class GenerateCodeForHashCodes
 
         // When the underlying type is a nullable value type (e.g. ushort?), EqualityComparer<T>.Default.GetHashCode
         // has [DisallowNull] on its parameter in .NET 10+, causing CS8607. Use null-safe approach instead.
-        string hashCodeExpression = item.UnderlyingType.IsNullableValueType()
-            ? "Value is null ? 0 : Value.GetHashCode()"
-            : $"global::System.Collections.Generic.EqualityComparer<{itemUnderlyingType}>.Default.GetHashCode(Value)";
+        string hashCodeExpression = item.IsUnderlyingAString && item.Config.GetStringDefaultComparerExpression() is { } structHashComparer
+            ? $"{structHashComparer}.GetHashCode(Value)"
+            : item.UnderlyingType.IsNullableValueType()
+                ? "Value is null ? 0 : Value.GetHashCode()"
+                : $"global::System.Collections.Generic.EqualityComparer<{itemUnderlyingType}>.Default.GetHashCode(Value)";
 
         return
             $$"""
-              
+
                         public readonly override global::System.Int32 GetHashCode()
                         {
                           return {{hashCodeExpression}};

--- a/src/Vogen/GenerateCodeForStringComparers.cs
+++ b/src/Vogen/GenerateCodeForStringComparers.cs
@@ -11,10 +11,7 @@ public static class GenerateCodeForStringComparers
             return string.Empty;
         }
 
-        bool hasDefaultComparison = item.Config.StringDefaultComparison is not StringComparisonDefault.Unspecified
-            and not StringComparisonDefault.Omit;
-
-        if (item.Config.StringComparers != StringComparersGeneration.Generate && !hasDefaultComparison)
+        if (item.Config.StringComparers != StringComparersGeneration.Generate)
         {
             return string.Empty;
         }

--- a/src/Vogen/GenerateCodeForStringComparers.cs
+++ b/src/Vogen/GenerateCodeForStringComparers.cs
@@ -11,7 +11,10 @@ public static class GenerateCodeForStringComparers
             return string.Empty;
         }
 
-        if(item.Config.StringComparers != StringComparersGeneration.Generate)
+        bool hasDefaultComparison = item.Config.StringDefaultComparison is not StringComparisonDefault.Unspecified
+            and not StringComparisonDefault.Omit;
+
+        if (item.Config.StringComparers != StringComparersGeneration.Generate && !hasDefaultComparison)
         {
             return string.Empty;
         }
@@ -35,9 +38,9 @@ public static class GenerateCodeForStringComparers
                             return _comparer.Equals(x._value, y._value);
                         }
                      
-                         public int GetHashCode({{tds.Identifier}} obj) 
+                         public int GetHashCode({{tds.Identifier}} obj)
                          {
-                            return _comparer.GetHashCode();
+                            return _comparer.GetHashCode(obj._value);
                          }
                      }
                      

--- a/src/Vogen/VogenConfiguration.cs
+++ b/src/Vogen/VogenConfiguration.cs
@@ -23,7 +23,8 @@ public record VogenConfiguration(
     OpenApiSchemaCustomizations OpenApiSchemaCustomizations,
     bool ExplicitlySpecifyTypeInValueObject,
     PrimitiveEqualityGeneration PrimitiveEqualityGeneration,
-    NumericsGeneration NumericsGeneration)
+    NumericsGeneration NumericsGeneration,
+    StringComparisonDefault StringDefaultComparison)
 {
     // Don't add default values here, they should be in DefaultInstance.
 
@@ -52,5 +53,17 @@ public record VogenConfiguration(
         OpenApiSchemaCustomizations: OpenApiSchemaCustomizations.Omit,
         ExplicitlySpecifyTypeInValueObject: false,
         PrimitiveEqualityGeneration: PrimitiveEqualityGeneration.GenerateOperatorsAndMethods,
-        NumericsGeneration: NumericsGeneration.Omit);
+        NumericsGeneration: NumericsGeneration.Omit,
+        StringDefaultComparison: StringComparisonDefault.Omit);
+
+    public string? GetStringDefaultComparerExpression() => StringDefaultComparison switch
+    {
+        StringComparisonDefault.Ordinal => "global::System.StringComparer.Ordinal",
+        StringComparisonDefault.OrdinalIgnoreCase => "global::System.StringComparer.OrdinalIgnoreCase",
+        StringComparisonDefault.CurrentCulture => "global::System.StringComparer.CurrentCulture",
+        StringComparisonDefault.CurrentCultureIgnoreCase => "global::System.StringComparer.CurrentCultureIgnoreCase",
+        StringComparisonDefault.InvariantCulture => "global::System.StringComparer.InvariantCulture",
+        StringComparisonDefault.InvariantCultureIgnoreCase => "global::System.StringComparer.InvariantCultureIgnoreCase",
+        _ => null
+    };
 }

--- a/tests/ConsumerTests/StringComparisons/ForClasses.cs
+++ b/tests/ConsumerTests/StringComparisons/ForClasses.cs
@@ -56,6 +56,24 @@ public class ForClasses
     }
 
     [Fact]
+    public void StringDefaultComparison_OrdinalIgnoreCase()
+    {
+        using var _ = new AssertionScope();
+
+        StringVo_Class_DefaultOrdinalIgnoreCase left = StringVo_Class_DefaultOrdinalIgnoreCase.From("abc");
+        StringVo_Class_DefaultOrdinalIgnoreCase right = StringVo_Class_DefaultOrdinalIgnoreCase.From("ABC");
+
+        (left == right).Should().BeTrue();
+        left.Equals(right).Should().BeTrue();
+        left.Equals("ABC").Should().BeTrue();
+        left.GetHashCode().Should().Be(right.GetHashCode());
+
+        Dictionary<StringVo_Class_DefaultOrdinalIgnoreCase, int> d = new();
+        d.Add(StringVo_Class_DefaultOrdinalIgnoreCase.From("one"), 1);
+        d.ContainsKey(StringVo_Class_DefaultOrdinalIgnoreCase.From("ONE")).Should().BeTrue();
+    }
+
+    [Fact]
     public void OrdinalIgnoreCase_in_a_dictionary()
     {
         Dictionary<StringVo_Class, int> d = new(StringVo_Class.Comparers.OrdinalIgnoreCase);

--- a/tests/ConsumerTests/StringComparisons/ForRecordClasses.cs
+++ b/tests/ConsumerTests/StringComparisons/ForRecordClasses.cs
@@ -56,6 +56,24 @@ public class ForRecordClasses
     }
 
     [Fact]
+    public void StringDefaultComparison_OrdinalIgnoreCase()
+    {
+        using var _ = new AssertionScope();
+
+        StringVo_RecordClass_DefaultOrdinalIgnoreCase left = StringVo_RecordClass_DefaultOrdinalIgnoreCase.From("abc");
+        StringVo_RecordClass_DefaultOrdinalIgnoreCase right = StringVo_RecordClass_DefaultOrdinalIgnoreCase.From("ABC");
+
+        (left == right).Should().BeTrue();
+        left.Equals(right).Should().BeTrue();
+        left.Equals("ABC").Should().BeTrue();
+        left.GetHashCode().Should().Be(right.GetHashCode());
+
+        Dictionary<StringVo_RecordClass_DefaultOrdinalIgnoreCase, int> d = new();
+        d.Add(StringVo_RecordClass_DefaultOrdinalIgnoreCase.From("one"), 1);
+        d.ContainsKey(StringVo_RecordClass_DefaultOrdinalIgnoreCase.From("ONE")).Should().BeTrue();
+    }
+
+    [Fact]
     public void OrdinalIgnoreCase_in_a_dictionary()
     {
         Dictionary<StringVo_RecordClass, int> d = new(StringVo_RecordClass.Comparers.OrdinalIgnoreCase);

--- a/tests/ConsumerTests/StringComparisons/ForRecordStructs.cs
+++ b/tests/ConsumerTests/StringComparisons/ForRecordStructs.cs
@@ -59,6 +59,24 @@ public class ForRecordStructs
         }
 
         [Fact]
+        public void StringDefaultComparison_OrdinalIgnoreCase()
+        {
+            using var _ = new AssertionScope();
+
+            StringVo_RecordStruct_DefaultOrdinalIgnoreCase left = StringVo_RecordStruct_DefaultOrdinalIgnoreCase.From("abc");
+            StringVo_RecordStruct_DefaultOrdinalIgnoreCase right = StringVo_RecordStruct_DefaultOrdinalIgnoreCase.From("ABC");
+
+            (left == right).Should().BeTrue();
+            left.Equals(right).Should().BeTrue();
+            left.Equals("ABC").Should().BeTrue();
+            left.GetHashCode().Should().Be(right.GetHashCode());
+
+            Dictionary<StringVo_RecordStruct_DefaultOrdinalIgnoreCase, int> d = new();
+            d.Add(StringVo_RecordStruct_DefaultOrdinalIgnoreCase.From("one"), 1);
+            d.ContainsKey(StringVo_RecordStruct_DefaultOrdinalIgnoreCase.From("ONE")).Should().BeTrue();
+        }
+
+        [Fact]
         public void OrdinalIgnoreCase_in_a_dictionary()
         {
             Dictionary<StringVo_RecordStruct, int> d = new(StringVo_RecordStruct.Comparers.OrdinalIgnoreCase);

--- a/tests/ConsumerTests/StringComparisons/ForStructs.cs
+++ b/tests/ConsumerTests/StringComparisons/ForStructs.cs
@@ -72,6 +72,24 @@ public class ForStructs
     }
 
     [Fact]
+    public void StringDefaultComparison_OrdinalIgnoreCase()
+    {
+        using var _ = new AssertionScope();
+
+        StringVo_Struct_DefaultOrdinalIgnoreCase left = StringVo_Struct_DefaultOrdinalIgnoreCase.From("abc");
+        StringVo_Struct_DefaultOrdinalIgnoreCase right = StringVo_Struct_DefaultOrdinalIgnoreCase.From("ABC");
+
+        (left == right).Should().BeTrue();
+        left.Equals(right).Should().BeTrue();
+        left.Equals("ABC").Should().BeTrue();
+        left.GetHashCode().Should().Be(right.GetHashCode());
+
+        Dictionary<StringVo_Struct_DefaultOrdinalIgnoreCase, int> d = new();
+        d.Add(StringVo_Struct_DefaultOrdinalIgnoreCase.From("one"), 1);
+        d.ContainsKey(StringVo_Struct_DefaultOrdinalIgnoreCase.From("ONE")).Should().BeTrue();
+    }
+
+    [Fact]
     public void OrdinalIgnoreCase_in_a_dictionary()
     {
         Dictionary<StringVo_Struct, int> d = new(StringVo_Struct.Comparers.OrdinalIgnoreCase);

--- a/tests/ConsumerTests/StringComparisons/Types.cs
+++ b/tests/ConsumerTests/StringComparisons/Types.cs
@@ -91,22 +91,22 @@ public partial struct StringVo_Struct_Generic
 {
 }
 
-[ValueObject(typeof(string), stringDefaultComparison: StringComparisonDefault.OrdinalIgnoreCase)]
+[ValueObject(typeof(string), Conversions.Unspecified, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
 public partial class StringVo_Class_DefaultOrdinalIgnoreCase
 {
 }
 
-[ValueObject(typeof(string), stringDefaultComparison: StringComparisonDefault.OrdinalIgnoreCase)]
+[ValueObject(typeof(string), Conversions.Unspecified, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
 public partial record class StringVo_RecordClass_DefaultOrdinalIgnoreCase
 {
 }
 
-[ValueObject(typeof(string), stringDefaultComparison: StringComparisonDefault.OrdinalIgnoreCase)]
+[ValueObject(typeof(string), Conversions.Unspecified, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
 public partial record struct StringVo_RecordStruct_DefaultOrdinalIgnoreCase
 {
 }
 
-[ValueObject(typeof(string), stringDefaultComparison: StringComparisonDefault.OrdinalIgnoreCase)]
+[ValueObject(typeof(string), Conversions.Unspecified, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
 public partial struct StringVo_Struct_DefaultOrdinalIgnoreCase
 {
 }

--- a/tests/ConsumerTests/StringComparisons/Types.cs
+++ b/tests/ConsumerTests/StringComparisons/Types.cs
@@ -90,3 +90,23 @@ public partial record struct StringVo_RecordStruct_Generic
 public partial struct StringVo_Struct_Generic
 {
 }
+
+[ValueObject(typeof(string), stringDefaultComparison: StringComparisonDefault.OrdinalIgnoreCase)]
+public partial class StringVo_Class_DefaultOrdinalIgnoreCase
+{
+}
+
+[ValueObject(typeof(string), stringDefaultComparison: StringComparisonDefault.OrdinalIgnoreCase)]
+public partial record class StringVo_RecordClass_DefaultOrdinalIgnoreCase
+{
+}
+
+[ValueObject(typeof(string), stringDefaultComparison: StringComparisonDefault.OrdinalIgnoreCase)]
+public partial record struct StringVo_RecordStruct_DefaultOrdinalIgnoreCase
+{
+}
+
+[ValueObject(typeof(string), stringDefaultComparison: StringComparisonDefault.OrdinalIgnoreCase)]
+public partial struct StringVo_Struct_DefaultOrdinalIgnoreCase
+{
+}

--- a/tests/ConsumerTests/StringComparisons/Types.cs
+++ b/tests/ConsumerTests/StringComparisons/Types.cs
@@ -91,22 +91,22 @@ public partial struct StringVo_Struct_Generic
 {
 }
 
-[ValueObject(typeof(string), Conversions.Unspecified, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
+[ValueObject(typeof(string), Conversions.Default, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
 public partial class StringVo_Class_DefaultOrdinalIgnoreCase
 {
 }
 
-[ValueObject(typeof(string), Conversions.Unspecified, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
+[ValueObject(typeof(string), Conversions.Default, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
 public partial record class StringVo_RecordClass_DefaultOrdinalIgnoreCase
 {
 }
 
-[ValueObject(typeof(string), Conversions.Unspecified, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
+[ValueObject(typeof(string), Conversions.Default, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
 public partial record struct StringVo_RecordStruct_DefaultOrdinalIgnoreCase
 {
 }
 
-[ValueObject(typeof(string), Conversions.Unspecified, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
+[ValueObject(typeof(string), Conversions.Default, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
 public partial struct StringVo_Struct_DefaultOrdinalIgnoreCase
 {
 }

--- a/tests/SnapshotTests/StringComparison/StringComparisonGenerationTests.cs
+++ b/tests/SnapshotTests/StringComparison/StringComparisonGenerationTests.cs
@@ -57,6 +57,23 @@ public class StringComparisonGenerationTests
     }
 
     [Fact]
+    public Task Generates_comparers_class_with_default_comparison_when_both_are_specified()
+    {
+        string source = $$"""
+                               using System;
+                               using Vogen;
+                               namespace Whatever;
+
+                               [ValueObject(typeof(string), Conversions.Default, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Generate, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
+                               public partial class StringThing { }
+                               """;
+
+        return new SnapshotRunner<ValueObjectGenerator>()
+            .WithSource(source)
+            .RunOnAllFrameworks();
+    }
+
+    [Fact]
     public Task Does_not_generate_the_equals_method_that_takes_a_StringComparison_when_not_a_string()
     {
         string source = $$"""

--- a/tests/SnapshotTests/StringComparison/StringComparisonGenerationTests.cs
+++ b/tests/SnapshotTests/StringComparison/StringComparisonGenerationTests.cs
@@ -47,7 +47,7 @@ public class StringComparisonGenerationTests
                                using Vogen;
                                namespace Whatever;
 
-                               [ValueObject(typeof(string), stringDefaultComparison: StringComparisonDefault.OrdinalIgnoreCase)]
+                               [ValueObject(typeof(string), Conversions.Default, null, Customizations.None, DeserializationStrictness.AllowValidAndKnownInstances, DebuggerAttributeGeneration.Default, ComparisonGeneration.Default, StringComparersGeneration.Unspecified, CastOperator.Unspecified, CastOperator.Unspecified, ParsableForStrings.Unspecified, ParsableForPrimitives.Unspecified, TryFromGeneration.Unspecified, IsInitializedMethodGeneration.Unspecified, PrimitiveEqualityGeneration.Unspecified, NumericsGeneration.Unspecified, StringComparisonDefault.OrdinalIgnoreCase)]
                                public partial class StringThing { }
                                """;
 

--- a/tests/SnapshotTests/StringComparison/StringComparisonGenerationTests.cs
+++ b/tests/SnapshotTests/StringComparison/StringComparisonGenerationTests.cs
@@ -40,6 +40,23 @@ public class StringComparisonGenerationTests
     }
 
     [Fact]
+    public Task Generates_with_default_comparison_OrdinalIgnoreCase()
+    {
+        string source = $$"""
+                               using System;
+                               using Vogen;
+                               namespace Whatever;
+
+                               [ValueObject(typeof(string), stringDefaultComparison: StringComparisonDefault.OrdinalIgnoreCase)]
+                               public partial class StringThing { }
+                               """;
+
+        return new SnapshotRunner<ValueObjectGenerator>()
+            .WithSource(source)
+            .RunOnAllFrameworks();
+    }
+
+    [Fact]
     public Task Does_not_generate_the_equals_method_that_takes_a_StringComparison_when_not_a_string()
     {
         string source = $$"""

--- a/tests/SnapshotTests/StringComparison/snapshots/snap-v4.8/StringComparisonGenerationTests.Generates_comparers_class_with_default_comparison_when_both_are_specified.verified.txt
+++ b/tests/SnapshotTests/StringComparison/snapshots/snap-v4.8/StringComparisonGenerationTests.Generates_comparers_class_with_default_comparison_when_both_are_specified.verified.txt
@@ -75,7 +75,7 @@ namespace Whatever
     [global::System.ComponentModel.TypeConverter(typeof(StringThingTypeConverter))]
     [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(StringThingDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: global::System.String, Value = { _value }")]
-    public partial class StringThing : global::System.IEquatable<StringThing>, global::System.IEquatable<global::System.String>, global::System.IComparable<StringThing>, global::System.IComparable, global::System.IParsable<StringThing>, global::System.IConvertible
+    public partial class StringThing : global::System.IEquatable<StringThing>, global::System.IEquatable<global::System.String>, global::System.IComparable<StringThing>, global::System.IComparable, global::System.IConvertible
     {
 #if DEBUG
 private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
@@ -250,7 +250,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
                 return true;
             }
 
-            return GetType() == other.GetType() && global::System.Collections.Generic.EqualityComparer<global::System.String>.Default.Equals(Value, other.Value);
+            return GetType() == other.GetType() && global::System.StringComparer.OrdinalIgnoreCase.Equals(Value, other.Value);
         }
 
         public global::System.Boolean Equals(StringThing other, global::System.Collections.Generic.IEqualityComparer<StringThing> comparer)
@@ -260,7 +260,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
         public global::System.Boolean Equals(global::System.String primitive)
         {
-            return Value.Equals(primitive);
+            return global::System.StringComparer.OrdinalIgnoreCase.Equals(Value, primitive);
         }
 
         public global::System.Boolean Equals(global::System.String primitive, global::System.StringComparer comparer)
@@ -275,8 +275,8 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
         public static global::System.Boolean operator ==(StringThing left, StringThing right) => Equals(left, right);
         public static global::System.Boolean operator !=(StringThing left, StringThing right) => !Equals(left, right);
-        public static global::System.Boolean operator ==(StringThing left, global::System.String right) => left.Value.Equals(right);
-        public static global::System.Boolean operator ==(global::System.String left, StringThing right) => right.Value.Equals(left);
+        public static global::System.Boolean operator ==(StringThing left, global::System.String right) => global::System.StringComparer.OrdinalIgnoreCase.Equals(left.Value, right);
+        public static global::System.Boolean operator ==(global::System.String left, StringThing right) => global::System.StringComparer.OrdinalIgnoreCase.Equals(left, right.Value);
         public static global::System.Boolean operator !=(global::System.String left, StringThing right) => !(left == right);
         public static global::System.Boolean operator !=(StringThing left, global::System.String right) => !(left == right);
         public static explicit operator StringThing(global::System.String value) => From(value);
@@ -350,51 +350,9 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
-        byte System.IConvertible.ToByte(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToByte(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
         char System.IConvertible.ToChar(global::System.IFormatProvider provider)
         {
             return IsInitialized() ? (Value as System.IConvertible).ToChar(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        System.DateTime System.IConvertible.ToDateTime(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToDateTime(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        decimal System.IConvertible.ToDecimal(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToDecimal(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        double System.IConvertible.ToDouble(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToDouble(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        short System.IConvertible.ToInt16(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToInt16(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        int System.IConvertible.ToInt32(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToInt32(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        long System.IConvertible.ToInt64(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToInt64(provider) : default;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
@@ -404,15 +362,15 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
-        float System.IConvertible.ToSingle(global::System.IFormatProvider provider)
+        byte System.IConvertible.ToByte(global::System.IFormatProvider provider)
         {
-            return IsInitialized() ? (Value as System.IConvertible).ToSingle(provider) : default;
+            return IsInitialized() ? (Value as System.IConvertible).ToByte(provider) : default;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
-        object System.IConvertible.ToType(global::System.Type @type, global::System.IFormatProvider provider)
+        short System.IConvertible.ToInt16(global::System.IFormatProvider provider)
         {
-            return IsInitialized() ? (Value as System.IConvertible).ToType(@type, provider) : default;
+            return IsInitialized() ? (Value as System.IConvertible).ToInt16(provider) : default;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
@@ -422,15 +380,57 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
+        int System.IConvertible.ToInt32(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToInt32(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
         uint System.IConvertible.ToUInt32(global::System.IFormatProvider provider)
         {
             return IsInitialized() ? (Value as System.IConvertible).ToUInt32(provider) : default;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
+        long System.IConvertible.ToInt64(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToInt64(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
         ulong System.IConvertible.ToUInt64(global::System.IFormatProvider provider)
         {
             return IsInitialized() ? (Value as System.IConvertible).ToUInt64(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
+        float System.IConvertible.ToSingle(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToSingle(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
+        double System.IConvertible.ToDouble(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToDouble(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
+        decimal System.IConvertible.ToDecimal(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToDecimal(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
+        System.DateTime System.IConvertible.ToDateTime(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToDateTime(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
+        object System.IConvertible.ToType(global::System.Type @type, global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToType(@type, provider) : default;
         }
 
 #nullable restore
@@ -440,14 +440,14 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
             {
                 global::System.Int32 hash = (global::System.Int32)2166136261;
                 hash = (hash * 16777619) ^ GetType().GetHashCode();
-                hash = (hash * 16777619) ^ global::System.Collections.Generic.EqualityComparer<global::System.String>.Default.GetHashCode(Value);
+                hash = (hash * 16777619) ^ global::System.StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
                 return hash;
             }
         }
 
         /// <inheritdoc cref = "string.ToString()"/>
         public override global::System.String ToString() => IsInitialized() ? Value.ToString() ?? "" : "[UNINITIALIZED]";
-        /// <inheritdoc cref = "string.ToString(System.IFormatProvider? )"/>
+        /// <inheritdoc cref = "string.ToString(System.IFormatProvider)"/>
         public global::System.String ToString(global::System.IFormatProvider provider) => IsInitialized() ? Value.ToString(provider) ?? "" : "[UNINITIALIZED]";
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         private void EnsureInitialized()

--- a/tests/SnapshotTests/StringComparison/snapshots/snap-v4.8/StringComparisonGenerationTests.Generates_when_specified.verified.txt
+++ b/tests/SnapshotTests/StringComparison/snapshots/snap-v4.8/StringComparisonGenerationTests.Generates_when_specified.verified.txt
@@ -208,7 +208,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
                 public int GetHashCode(StringThing obj)
                 {
-                    return _comparer.GetHashCode();
+                    return _comparer.GetHashCode(obj._value);
                 }
             }
 

--- a/tests/SnapshotTests/StringComparison/snapshots/snap-v4.8/StringComparisonGenerationTests.Generates_with_default_comparison_OrdinalIgnoreCase.verified.txt
+++ b/tests/SnapshotTests/StringComparison/snapshots/snap-v4.8/StringComparisonGenerationTests.Generates_with_default_comparison_OrdinalIgnoreCase.verified.txt
@@ -75,7 +75,7 @@ namespace Whatever
     [global::System.ComponentModel.TypeConverter(typeof(StringThingTypeConverter))]
     [global::System.Diagnostics.DebuggerTypeProxyAttribute(typeof(StringThingDebugView))]
     [global::System.Diagnostics.DebuggerDisplayAttribute("Underlying type: global::System.String, Value = { _value }")]
-    public partial class StringThing : global::System.IEquatable<StringThing>, global::System.IEquatable<global::System.String>, global::System.IComparable<StringThing>, global::System.IComparable, global::System.IParsable<StringThing>, global::System.IConvertible
+    public partial class StringThing : global::System.IEquatable<StringThing>, global::System.IEquatable<global::System.String>, global::System.IComparable<StringThing>, global::System.IComparable, global::System.IConvertible
     {
 #if DEBUG
 private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
@@ -190,37 +190,6 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 #else
         public bool IsInitialized() => _isInitialized;
 #endif
-#nullable disable
-        public static class Comparers
-        {
-            private class __StringEqualityComparer : global::System.Collections.Generic.IEqualityComparer<StringThing>
-            {
-                readonly global::System.StringComparer _comparer;
-                public __StringEqualityComparer(global::System.StringComparer comparer)
-                {
-                    _comparer = comparer;
-                }
-
-                public bool Equals(StringThing x, StringThing y)
-                {
-                    return _comparer.Equals(x._value, y._value);
-                }
-
-                public int GetHashCode(StringThing obj)
-                {
-                    return _comparer.GetHashCode(obj._value);
-                }
-            }
-
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> Ordinal => new __StringEqualityComparer(global::System.StringComparer.Ordinal);
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> OrdinalIgnoreCase => new __StringEqualityComparer(global::System.StringComparer.OrdinalIgnoreCase);
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> CurrentCulture => new __StringEqualityComparer(global::System.StringComparer.CurrentCulture);
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> CurrentCultureIgnoreCase => new __StringEqualityComparer(global::System.StringComparer.CurrentCultureIgnoreCase);
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> InvariantCulture => new __StringEqualityComparer(global::System.StringComparer.InvariantCulture);
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> InvariantCultureIgnoreCase => new __StringEqualityComparer(global::System.StringComparer.InvariantCultureIgnoreCase);
-#nullable restore
-        }
-
         // only called internally when something has been deserialized into
         // its primitive type.
         private static StringThing __Deserialize(global::System.String value)
@@ -250,7 +219,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
                 return true;
             }
 
-            return GetType() == other.GetType() && global::System.Collections.Generic.EqualityComparer<global::System.String>.Default.Equals(Value, other.Value);
+            return GetType() == other.GetType() && global::System.StringComparer.OrdinalIgnoreCase.Equals(Value, other.Value);
         }
 
         public global::System.Boolean Equals(StringThing other, global::System.Collections.Generic.IEqualityComparer<StringThing> comparer)
@@ -260,7 +229,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
         public global::System.Boolean Equals(global::System.String primitive)
         {
-            return Value.Equals(primitive);
+            return global::System.StringComparer.OrdinalIgnoreCase.Equals(Value, primitive);
         }
 
         public global::System.Boolean Equals(global::System.String primitive, global::System.StringComparer comparer)
@@ -275,8 +244,8 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
         public static global::System.Boolean operator ==(StringThing left, StringThing right) => Equals(left, right);
         public static global::System.Boolean operator !=(StringThing left, StringThing right) => !Equals(left, right);
-        public static global::System.Boolean operator ==(StringThing left, global::System.String right) => left.Value.Equals(right);
-        public static global::System.Boolean operator ==(global::System.String left, StringThing right) => right.Value.Equals(left);
+        public static global::System.Boolean operator ==(StringThing left, global::System.String right) => global::System.StringComparer.OrdinalIgnoreCase.Equals(left.Value, right);
+        public static global::System.Boolean operator ==(global::System.String left, StringThing right) => global::System.StringComparer.OrdinalIgnoreCase.Equals(left, right.Value);
         public static global::System.Boolean operator !=(global::System.String left, StringThing right) => !(left == right);
         public static global::System.Boolean operator !=(StringThing left, global::System.String right) => !(left == right);
         public static explicit operator StringThing(global::System.String value) => From(value);
@@ -350,51 +319,9 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
-        byte System.IConvertible.ToByte(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToByte(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
         char System.IConvertible.ToChar(global::System.IFormatProvider provider)
         {
             return IsInitialized() ? (Value as System.IConvertible).ToChar(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        System.DateTime System.IConvertible.ToDateTime(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToDateTime(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        decimal System.IConvertible.ToDecimal(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToDecimal(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        double System.IConvertible.ToDouble(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToDouble(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        short System.IConvertible.ToInt16(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToInt16(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        int System.IConvertible.ToInt32(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToInt32(provider) : default;
-        }
-
-        /// <inheritdoc cref = "System.IConvertible"/>
-        long System.IConvertible.ToInt64(global::System.IFormatProvider provider)
-        {
-            return IsInitialized() ? (Value as System.IConvertible).ToInt64(provider) : default;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
@@ -404,15 +331,15 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
-        float System.IConvertible.ToSingle(global::System.IFormatProvider provider)
+        byte System.IConvertible.ToByte(global::System.IFormatProvider provider)
         {
-            return IsInitialized() ? (Value as System.IConvertible).ToSingle(provider) : default;
+            return IsInitialized() ? (Value as System.IConvertible).ToByte(provider) : default;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
-        object System.IConvertible.ToType(global::System.Type @type, global::System.IFormatProvider provider)
+        short System.IConvertible.ToInt16(global::System.IFormatProvider provider)
         {
-            return IsInitialized() ? (Value as System.IConvertible).ToType(@type, provider) : default;
+            return IsInitialized() ? (Value as System.IConvertible).ToInt16(provider) : default;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
@@ -422,15 +349,57 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
+        int System.IConvertible.ToInt32(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToInt32(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
         uint System.IConvertible.ToUInt32(global::System.IFormatProvider provider)
         {
             return IsInitialized() ? (Value as System.IConvertible).ToUInt32(provider) : default;
         }
 
         /// <inheritdoc cref = "System.IConvertible"/>
+        long System.IConvertible.ToInt64(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToInt64(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
         ulong System.IConvertible.ToUInt64(global::System.IFormatProvider provider)
         {
             return IsInitialized() ? (Value as System.IConvertible).ToUInt64(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
+        float System.IConvertible.ToSingle(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToSingle(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
+        double System.IConvertible.ToDouble(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToDouble(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
+        decimal System.IConvertible.ToDecimal(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToDecimal(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
+        System.DateTime System.IConvertible.ToDateTime(global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToDateTime(provider) : default;
+        }
+
+        /// <inheritdoc cref = "System.IConvertible"/>
+        object System.IConvertible.ToType(global::System.Type @type, global::System.IFormatProvider provider)
+        {
+            return IsInitialized() ? (Value as System.IConvertible).ToType(@type, provider) : default;
         }
 
 #nullable restore
@@ -440,14 +409,14 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
             {
                 global::System.Int32 hash = (global::System.Int32)2166136261;
                 hash = (hash * 16777619) ^ GetType().GetHashCode();
-                hash = (hash * 16777619) ^ global::System.Collections.Generic.EqualityComparer<global::System.String>.Default.GetHashCode(Value);
+                hash = (hash * 16777619) ^ global::System.StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
                 return hash;
             }
         }
 
         /// <inheritdoc cref = "string.ToString()"/>
         public override global::System.String ToString() => IsInitialized() ? Value.ToString() ?? "" : "[UNINITIALIZED]";
-        /// <inheritdoc cref = "string.ToString(System.IFormatProvider? )"/>
+        /// <inheritdoc cref = "string.ToString(System.IFormatProvider)"/>
         public global::System.String ToString(global::System.IFormatProvider provider) => IsInitialized() ? Value.ToString(provider) ?? "" : "[UNINITIALIZED]";
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         private void EnsureInitialized()

--- a/tests/SnapshotTests/StringComparison/snapshots/snap-v8.0/StringComparisonGenerationTests.Generates_comparers_class_with_default_comparison_when_both_are_specified.verified.txt
+++ b/tests/SnapshotTests/StringComparison/snapshots/snap-v8.0/StringComparisonGenerationTests.Generates_comparers_class_with_default_comparison_when_both_are_specified.verified.txt
@@ -250,7 +250,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
                 return true;
             }
 
-            return GetType() == other.GetType() && global::System.Collections.Generic.EqualityComparer<global::System.String>.Default.Equals(Value, other.Value);
+            return GetType() == other.GetType() && global::System.StringComparer.OrdinalIgnoreCase.Equals(Value, other.Value);
         }
 
         public global::System.Boolean Equals(StringThing other, global::System.Collections.Generic.IEqualityComparer<StringThing> comparer)
@@ -260,7 +260,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
         public global::System.Boolean Equals(global::System.String primitive)
         {
-            return Value.Equals(primitive);
+            return global::System.StringComparer.OrdinalIgnoreCase.Equals(Value, primitive);
         }
 
         public global::System.Boolean Equals(global::System.String primitive, global::System.StringComparer comparer)
@@ -275,8 +275,8 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
         public static global::System.Boolean operator ==(StringThing left, StringThing right) => Equals(left, right);
         public static global::System.Boolean operator !=(StringThing left, StringThing right) => !Equals(left, right);
-        public static global::System.Boolean operator ==(StringThing left, global::System.String right) => left.Value.Equals(right);
-        public static global::System.Boolean operator ==(global::System.String left, StringThing right) => right.Value.Equals(left);
+        public static global::System.Boolean operator ==(StringThing left, global::System.String right) => global::System.StringComparer.OrdinalIgnoreCase.Equals(left.Value, right);
+        public static global::System.Boolean operator ==(global::System.String left, StringThing right) => global::System.StringComparer.OrdinalIgnoreCase.Equals(left, right.Value);
         public static global::System.Boolean operator !=(global::System.String left, StringThing right) => !(left == right);
         public static global::System.Boolean operator !=(StringThing left, global::System.String right) => !(left == right);
         public static explicit operator StringThing(global::System.String value) => From(value);
@@ -440,7 +440,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
             {
                 global::System.Int32 hash = (global::System.Int32)2166136261;
                 hash = (hash * 16777619) ^ GetType().GetHashCode();
-                hash = (hash * 16777619) ^ global::System.Collections.Generic.EqualityComparer<global::System.String>.Default.GetHashCode(Value);
+                hash = (hash * 16777619) ^ global::System.StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
                 return hash;
             }
         }

--- a/tests/SnapshotTests/StringComparison/snapshots/snap-v8.0/StringComparisonGenerationTests.Generates_with_default_comparison_OrdinalIgnoreCase.verified.txt
+++ b/tests/SnapshotTests/StringComparison/snapshots/snap-v8.0/StringComparisonGenerationTests.Generates_with_default_comparison_OrdinalIgnoreCase.verified.txt
@@ -190,37 +190,6 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 #else
         public bool IsInitialized() => _isInitialized;
 #endif
-#nullable disable
-        public static class Comparers
-        {
-            private class __StringEqualityComparer : global::System.Collections.Generic.IEqualityComparer<StringThing>
-            {
-                readonly global::System.StringComparer _comparer;
-                public __StringEqualityComparer(global::System.StringComparer comparer)
-                {
-                    _comparer = comparer;
-                }
-
-                public bool Equals(StringThing x, StringThing y)
-                {
-                    return _comparer.Equals(x._value, y._value);
-                }
-
-                public int GetHashCode(StringThing obj)
-                {
-                    return _comparer.GetHashCode(obj._value);
-                }
-            }
-
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> Ordinal => new __StringEqualityComparer(global::System.StringComparer.Ordinal);
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> OrdinalIgnoreCase => new __StringEqualityComparer(global::System.StringComparer.OrdinalIgnoreCase);
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> CurrentCulture => new __StringEqualityComparer(global::System.StringComparer.CurrentCulture);
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> CurrentCultureIgnoreCase => new __StringEqualityComparer(global::System.StringComparer.CurrentCultureIgnoreCase);
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> InvariantCulture => new __StringEqualityComparer(global::System.StringComparer.InvariantCulture);
-            public static global::System.Collections.Generic.IEqualityComparer<StringThing> InvariantCultureIgnoreCase => new __StringEqualityComparer(global::System.StringComparer.InvariantCultureIgnoreCase);
-#nullable restore
-        }
-
         // only called internally when something has been deserialized into
         // its primitive type.
         private static StringThing __Deserialize(global::System.String value)
@@ -250,7 +219,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
                 return true;
             }
 
-            return GetType() == other.GetType() && global::System.Collections.Generic.EqualityComparer<global::System.String>.Default.Equals(Value, other.Value);
+            return GetType() == other.GetType() && global::System.StringComparer.OrdinalIgnoreCase.Equals(Value, other.Value);
         }
 
         public global::System.Boolean Equals(StringThing other, global::System.Collections.Generic.IEqualityComparer<StringThing> comparer)
@@ -260,7 +229,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
         public global::System.Boolean Equals(global::System.String primitive)
         {
-            return Value.Equals(primitive);
+            return global::System.StringComparer.OrdinalIgnoreCase.Equals(Value, primitive);
         }
 
         public global::System.Boolean Equals(global::System.String primitive, global::System.StringComparer comparer)
@@ -275,8 +244,8 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
         public static global::System.Boolean operator ==(StringThing left, StringThing right) => Equals(left, right);
         public static global::System.Boolean operator !=(StringThing left, StringThing right) => !Equals(left, right);
-        public static global::System.Boolean operator ==(StringThing left, global::System.String right) => left.Value.Equals(right);
-        public static global::System.Boolean operator ==(global::System.String left, StringThing right) => right.Value.Equals(left);
+        public static global::System.Boolean operator ==(StringThing left, global::System.String right) => global::System.StringComparer.OrdinalIgnoreCase.Equals(left.Value, right);
+        public static global::System.Boolean operator ==(global::System.String left, StringThing right) => global::System.StringComparer.OrdinalIgnoreCase.Equals(left, right.Value);
         public static global::System.Boolean operator !=(global::System.String left, StringThing right) => !(left == right);
         public static global::System.Boolean operator !=(StringThing left, global::System.String right) => !(left == right);
         public static explicit operator StringThing(global::System.String value) => From(value);
@@ -440,7 +409,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
             {
                 global::System.Int32 hash = (global::System.Int32)2166136261;
                 hash = (hash * 16777619) ^ GetType().GetHashCode();
-                hash = (hash * 16777619) ^ global::System.Collections.Generic.EqualityComparer<global::System.String>.Default.GetHashCode(Value);
+                hash = (hash * 16777619) ^ global::System.StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
                 return hash;
             }
         }

--- a/tests/SnapshotTests/StringComparison/snapshots/snap-v9.0/StringComparisonGenerationTests.Generates_comparers_class_with_default_comparison_when_both_are_specified.verified.txt
+++ b/tests/SnapshotTests/StringComparison/snapshots/snap-v9.0/StringComparisonGenerationTests.Generates_comparers_class_with_default_comparison_when_both_are_specified.verified.txt
@@ -190,6 +190,37 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 #else
         public bool IsInitialized() => _isInitialized;
 #endif
+#nullable disable
+        public static class Comparers
+        {
+            private class __StringEqualityComparer : global::System.Collections.Generic.IEqualityComparer<StringThing>
+            {
+                readonly global::System.StringComparer _comparer;
+                public __StringEqualityComparer(global::System.StringComparer comparer)
+                {
+                    _comparer = comparer;
+                }
+
+                public bool Equals(StringThing x, StringThing y)
+                {
+                    return _comparer.Equals(x._value, y._value);
+                }
+
+                public int GetHashCode(StringThing obj)
+                {
+                    return _comparer.GetHashCode(obj._value);
+                }
+            }
+
+            public static global::System.Collections.Generic.IEqualityComparer<StringThing> Ordinal => new __StringEqualityComparer(global::System.StringComparer.Ordinal);
+            public static global::System.Collections.Generic.IEqualityComparer<StringThing> OrdinalIgnoreCase => new __StringEqualityComparer(global::System.StringComparer.OrdinalIgnoreCase);
+            public static global::System.Collections.Generic.IEqualityComparer<StringThing> CurrentCulture => new __StringEqualityComparer(global::System.StringComparer.CurrentCulture);
+            public static global::System.Collections.Generic.IEqualityComparer<StringThing> CurrentCultureIgnoreCase => new __StringEqualityComparer(global::System.StringComparer.CurrentCultureIgnoreCase);
+            public static global::System.Collections.Generic.IEqualityComparer<StringThing> InvariantCulture => new __StringEqualityComparer(global::System.StringComparer.InvariantCulture);
+            public static global::System.Collections.Generic.IEqualityComparer<StringThing> InvariantCultureIgnoreCase => new __StringEqualityComparer(global::System.StringComparer.InvariantCultureIgnoreCase);
+#nullable restore
+        }
+
         // only called internally when something has been deserialized into
         // its primitive type.
         private static StringThing __Deserialize(global::System.String value)

--- a/tests/SnapshotTests/StringComparison/snapshots/snap-v9.0/StringComparisonGenerationTests.Generates_with_default_comparison_OrdinalIgnoreCase.verified.txt
+++ b/tests/SnapshotTests/StringComparison/snapshots/snap-v9.0/StringComparisonGenerationTests.Generates_with_default_comparison_OrdinalIgnoreCase.verified.txt
@@ -250,7 +250,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
                 return true;
             }
 
-            return GetType() == other.GetType() && global::System.Collections.Generic.EqualityComparer<global::System.String>.Default.Equals(Value, other.Value);
+            return GetType() == other.GetType() && global::System.StringComparer.OrdinalIgnoreCase.Equals(Value, other.Value);
         }
 
         public global::System.Boolean Equals(StringThing other, global::System.Collections.Generic.IEqualityComparer<StringThing> comparer)
@@ -260,7 +260,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
         public global::System.Boolean Equals(global::System.String primitive)
         {
-            return Value.Equals(primitive);
+            return global::System.StringComparer.OrdinalIgnoreCase.Equals(Value, primitive);
         }
 
         public global::System.Boolean Equals(global::System.String primitive, global::System.StringComparer comparer)
@@ -275,8 +275,8 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
 
         public static global::System.Boolean operator ==(StringThing left, StringThing right) => Equals(left, right);
         public static global::System.Boolean operator !=(StringThing left, StringThing right) => !Equals(left, right);
-        public static global::System.Boolean operator ==(StringThing left, global::System.String right) => left.Value.Equals(right);
-        public static global::System.Boolean operator ==(global::System.String left, StringThing right) => right.Value.Equals(left);
+        public static global::System.Boolean operator ==(StringThing left, global::System.String right) => global::System.StringComparer.OrdinalIgnoreCase.Equals(left.Value, right);
+        public static global::System.Boolean operator ==(global::System.String left, StringThing right) => global::System.StringComparer.OrdinalIgnoreCase.Equals(left, right.Value);
         public static global::System.Boolean operator !=(global::System.String left, StringThing right) => !(left == right);
         public static global::System.Boolean operator !=(StringThing left, global::System.String right) => !(left == right);
         public static explicit operator StringThing(global::System.String value) => From(value);
@@ -440,7 +440,7 @@ private readonly global::System.Diagnostics.StackTrace _stackTrace  = null!;
             {
                 global::System.Int32 hash = (global::System.Int32)2166136261;
                 hash = (hash * 16777619) ^ GetType().GetHashCode();
-                hash = (hash * 16777619) ^ global::System.Collections.Generic.EqualityComparer<global::System.String>.Default.GetHashCode(Value);
+                hash = (hash * 16777619) ^ global::System.StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
                 return hash;
             }
         }

--- a/tests/Vogen.Tests/ConfigurationTests/VogenConfigurationTests.cs
+++ b/tests/Vogen.Tests/ConfigurationTests/VogenConfigurationTests.cs
@@ -74,7 +74,8 @@ public class VogenConfigurationTests
                 OpenApiSchemaCustomizations.Unspecified,
                 false,
                 PrimitiveEqualityGeneration.GenerateOperatorsAndMethods,
-                NumericsGeneration.Omit);
+                NumericsGeneration.Omit,
+                StringComparisonDefault.Omit);
     }
 
     public class Primitive_equality_generation
@@ -150,7 +151,8 @@ public class VogenConfigurationTests
                 OpenApiSchemaCustomizations: OpenApiSchemaCustomizations.Unspecified,
                 false,
                 PrimitiveEqualityGeneration.GenerateOperatorsAndMethods,
-                NumericsGeneration.Omit);
+                NumericsGeneration.Omit,
+                StringComparisonDefault.Omit);
     }
 
     public class Conversion
@@ -256,7 +258,8 @@ public class VogenConfigurationTests
                 OpenApiSchemaCustomizations.Unspecified,
                 false,
                 PrimitiveEqualityGeneration.GenerateOperatorsAndMethods,
-                NumericsGeneration.Omit);
+                NumericsGeneration.Omit,
+                StringComparisonDefault.Omit);
     }
 
     public class Comparable


### PR DESCRIPTION
PR for feature request #947 

Adds a new `StringComparisonDefault` enum and `stringDefaultComparison` parameter to `ValueObjectAttribute`, `ValueObjectAttribute<T>`, and `VogenDefaultsAttribute`. When set, the specified `StringComparer` iswired into all five equality/hashing entry points on string-backed value objects: `Equals(T)`, `Equals(string)`, `operator ==` (both directions), and `GetHashCode()`. The `Comparers` nested class is generated implicitly when a default comparison is specified.

Two new diagnostics:
- VOG039 (warning): `stringDefaultComparison` set on a non-string type
- VOG040 (error): `stringComparers: Omit` explicitly conflicts with `stringDefaultComparison`

Also fixes a bug in the existing `Comparers` class where `GetHashCode` called `_comparer.GetHashCode()` (the comparer's own object hash) instead of `_comparer.GetHashCode(obj._value)`, causing all values to hash identically and degrading dictionary lookups to O(n).

Fyi, this includes the Fix in #946 (but not the tests in it)