### PR TITLE
Null-propagating explicit to-primitive cast for reference-type value objects (#945)

### DIFF
--- a/src/Vogen/GenerateCodeForCastingOperators.cs
+++ b/src/Vogen/GenerateCodeForCastingOperators.cs
@@ -24,10 +24,30 @@ public static class GenerateCodeForCastingOperators
             sb.AppendLine($"public static explicit operator {wrapper}({primitive} value) => From(value);");
         }
 
+        // The explicit to-primitive cast propagates null (returns null for a null receiver instead of
+        // throwing) for reference-type wrappers over a reference-type underlying (e.g. string) in a
+        // nullable-enabled context. Value-type underlyings are left alone so the cast result type stays
+        // `int` rather than `int?` (which would stop `(int)vo` compiling). Structs already lift over
+        // Nullable<T>, and with nullable disabled there's no NRT contract to express.
+        bool nullPropagateExplicit =
+            item.IsTheWrapperAReferenceType
+            && !item.IsTheUnderlyingAValueType
+            && item.Nullable.IsEnabled;
+
         // Generate the call to the Value property so that it throws if uninitialized.
         if (config.ToPrimitiveCasting == CastOperator.Explicit || sag.HasFlag(StaticAbstractsGeneration.ExplicitCastToPrimitive))
         {
-            sb.AppendLine($"public static explicit operator {primitive}({wrapper} value) => value.Value;");
+            // Don't propagate when the cast is part of the static-abstract IVogen interface - the
+            // nullable signature can't satisfy the declared `operator TPrimitive(TSelf)`.
+            if (nullPropagateExplicit && !sag.HasFlag(StaticAbstractsGeneration.ExplicitCastToPrimitive))
+            {
+                sb.AppendLine("[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(value))]");
+                sb.AppendLine($"public static explicit operator {primitive}?({wrapper}? value) => value is null ? null : value.Value;");
+            }
+            else
+            {
+                sb.AppendLine($"public static explicit operator {primitive}({wrapper} value) => value.Value;");
+            }
         }
 
         // Generate the call to the _value field so that it doesn't throw if uninitialized.

--- a/tests/ConsumerTests/Casting/ForClasses.cs
+++ b/tests/ConsumerTests/Casting/ForClasses.cs
@@ -24,6 +24,18 @@ public class ForClasses
     }
 
     [Fact]
+    public void Null_reference_propagates_to_null_by_default()
+    {
+        using var _ = new AssertionScope();
+
+        Vo? nullVo = null;
+
+        string? prim = (string?)nullVo;
+
+        prim.Should().BeNull();
+    }
+
+    [Fact]
     public void Just_implicit_to_primitive()
     {
         using var _ = new AssertionScope();

--- a/tests/SnapshotTests/Casting/NullPropagatingCastTests.cs
+++ b/tests/SnapshotTests/Casting/NullPropagatingCastTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.CodeAnalysis;
+using Shared;
+using Vogen;
+
+namespace SnapshotTests.Casting;
+
+public class NullPropagatingCastTests
+{
+    [Fact]
+    public async Task Reference_type_underlying_propagates_null()
+    {
+        var source = """
+                     #nullable enable
+                     using Vogen;
+                     namespace Whatever;
+
+                     [ValueObject<string>]
+                     public partial class Vo;
+                     """;
+
+        var generated = await GetGeneratedSource(source);
+
+        using var _ = new AssertionScope();
+        generated.Should().Contain("public static explicit operator global::System.String? (Vo? value) => value is null ? null : value.Value;");
+        generated.Should().Contain("[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(value))]");
+    }
+
+    [Fact]
+    public async Task Value_type_underlying_does_not_propagate()
+    {
+        // Propagating would change the cast result type from int to int?, which stops (int)vo compiling.
+        var source = """
+                     #nullable enable
+                     using Vogen;
+                     namespace Whatever;
+
+                     [ValueObject<int>]
+                     public partial class Vo;
+                     """;
+
+        var generated = await GetGeneratedSource(source);
+
+        using var _ = new AssertionScope();
+        generated.Should().Contain("public static explicit operator global::System.Int32(Vo value) => value.Value;");
+        generated.Should().NotContain("value is null ? null : value.Value");
+    }
+
+    [Fact]
+    public async Task Does_not_propagate_the_implicit_cast()
+    {
+        // Implicit to-primitive casts are intentionally left unchanged - making them nullable would
+        // defeat the `string x = vo;` convenience that opting into an implicit cast asks for.
+        var source = """
+                     #nullable enable
+                     using Vogen;
+                     namespace Whatever;
+
+                     [ValueObject<string>(toPrimitiveCasting: CastOperator.Implicit)]
+                     public partial class Vo;
+                     """;
+
+        var generated = await GetGeneratedSource(source);
+
+        using var _ = new AssertionScope();
+        generated.Should().Contain("public static implicit operator global::System.String(Vo vo) => vo._value");
+        generated.Should().NotContain("vo is null ? null");
+    }
+
+    [Fact]
+    public async Task Struct_wrapper_does_not_propagate()
+    {
+        var source = """
+                     #nullable enable
+                     using Vogen;
+                     namespace Whatever;
+
+                     [ValueObject<string>]
+                     public partial struct Vo;
+                     """;
+
+        var generated = await GetGeneratedSource(source);
+
+        using var _ = new AssertionScope();
+        generated.Should().Contain("public static explicit operator global::System.String(Vo value) => value.Value;");
+        generated.Should().NotContain("value is null ? null : value.Value");
+    }
+
+    [Fact]
+    public async Task Nullable_disabled_context_does_not_propagate()
+    {
+        var source = """
+                     using Vogen;
+                     namespace Whatever;
+
+                     [ValueObject<string>]
+                     public partial class Vo;
+                     """;
+
+        var generated = await GetGeneratedSource(source);
+
+        generated.Should().NotContain("value is null ? null : value.Value");
+    }
+
+    private static async Task<string> GetGeneratedSource(string source)
+    {
+        (ImmutableArray<Diagnostic> diagnostics, SyntaxTree[] trees) =
+            await new ProjectBuilder()
+                .WithUserSource(source)
+                .WithTargetFramework(TargetFramework.Net9_0)
+                .GetGeneratedOutput<ValueObjectGenerator>(ignoreInitialCompilationErrors: false);
+
+        diagnostics.Should().BeEmpty();
+
+        return string.Join("\n", trees.Select(t => t.ToString()));
+    }
+}

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v8.0/GeneralTests.No_validation.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v8.0/GeneralTests.No_validation.verified.txt
@@ -243,7 +243,8 @@ private readonly global::System.Diagnostics.StackTrace? _stackTrace  = null!;
     public static global::System.Boolean operator !=(global::C<System.Int32>? left, MyVo? right) => !(left == right);
     public static global::System.Boolean operator !=(MyVo? left, global::C<System.Int32>? right) => !(left == right);
     public static explicit operator MyVo(global::C<System.Int32> value) => From(value);
-    public static explicit operator global::C<System.Int32>(MyVo value) => value.Value;
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(value))]
+    public static explicit operator global::C<System.Int32>? (MyVo? value) => value is null ? null : value.Value;
 #nullable disable
 #nullable restore
     public override global::System.Int32 GetHashCode()

--- a/tests/SnapshotTests/OpenApi/snapshots/snap-vAspNetCore8.0/SwashbuckleTests.Treats_custom_IParsable_as_string.verified.txt
+++ b/tests/SnapshotTests/OpenApi/snapshots/snap-vAspNetCore8.0/SwashbuckleTests.Treats_custom_IParsable_as_string.verified.txt
@@ -289,7 +289,8 @@ private readonly global::System.Diagnostics.StackTrace? _stackTrace  = null!;
         public static global::System.Boolean operator !=(global::MyNamespace.C? left, MyVo? right) => !(left == right);
         public static global::System.Boolean operator !=(MyVo? left, global::MyNamespace.C? right) => !(left == right);
         public static explicit operator MyVo(global::MyNamespace.C value) => From(value);
-        public static explicit operator global::MyNamespace.C(MyVo value) => value.Value;
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(value))]
+        public static explicit operator global::MyNamespace.C? (MyVo? value) => value is null ? null : value.Value;
         /// <inheritdoc cref = "MyNamespace.C.TryParse(string? , System.IFormatProvider? , out MyNamespace.C)"/>
         /// <summary>
         /// </summary>

--- a/tests/SnapshotTests/OpenApi/snapshots/snap-vAspNetCore9.0/OpenApiTests.Treats_custom_IParsable_as_string.verified.txt
+++ b/tests/SnapshotTests/OpenApi/snapshots/snap-vAspNetCore9.0/OpenApiTests.Treats_custom_IParsable_as_string.verified.txt
@@ -306,7 +306,8 @@ private readonly global::System.Diagnostics.StackTrace? _stackTrace  = null!;
         public static global::System.Boolean operator !=(global::MyNamespace.C? left, MyVo? right) => !(left == right);
         public static global::System.Boolean operator !=(MyVo? left, global::MyNamespace.C? right) => !(left == right);
         public static explicit operator MyVo(global::MyNamespace.C value) => From(value);
-        public static explicit operator global::MyNamespace.C(MyVo value) => value.Value;
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(value))]
+        public static explicit operator global::MyNamespace.C? (MyVo? value) => value is null ? null : value.Value;
         /// <inheritdoc cref = "MyNamespace.C.TryParse(string? , System.IFormatProvider? , out MyNamespace.C)"/>
         /// <summary>
         /// </summary>


### PR DESCRIPTION
Closes #945.

Casting a `null` reference-type value object to its primitive currently throws a raw `NullReferenceException`:

```csharp
Code? code = null;
var s = (string?)code; // NRE
```

The generated **explicit** to-primitive cast now propagates `null` — `(string?)code` yields `null` — mirroring how C# lifts user-defined conversions over `Nullable<T>` for struct-based VOs, and matching what primitives already do.

As requested in review, there's **no configuration** — it's emitted unconditionally.

### Behaviour

- **Reference-type underlyings** (e.g. `string`) propagate null: `operator string?(Code? value) => value is null ? null : value.Value;`.
- **Value-type underlyings** are left unchanged, so the cast result type stays `int` rather than `int?` (otherwise `(int)vo` would stop compiling). Happy to include them too if you'd prefer — it's a one-liner — but that's a harder break.
- Applies to the **explicit** cast only; implicit to-primitive casts are unchanged (making them nullable would defeat the `string s = vo;` convenience).
- The generated operator carries `[return: NotNullIfNotNull(nameof(value))]`, so tooling (e.g. Mapperly) can read the nullable-reference contract and drop its own null guards.
- No-op for structs, for nullable-disabled contexts, and where it would clash with static-abstract (`IVogen`) cast generation.

## Breaking change (v9)

For reference-type underlyings the explicit cast now returns a nullable primitive (`string?` instead of `string`). Existing explicit-cast call sites keep compiling (the explicit cast form suppresses the nullability warning); the change is in the operator's return type / NRT contract.

## Tests

- New `NullPropagatingCastTests` covering: reference-underlying propagation, value-underlying left unchanged, implicit-cast unchanged, struct no-op, and nullable-disabled no-op.
- Consumer behaviour test for `(string?)null -> null`.
- Full suites green: SnapshotTests, Vogen.Tests, AnalyzerTests, ConsumerTests, and samples build. Three existing snapshots updated to the propagating form.
