### PR TITLE
Fix Orleans nullable string value object serialization

### DIFF
--- a/src/Vogen/GenerateCodeForOrleansSerializers.cs
+++ b/src/Vogen/GenerateCodeForOrleansSerializers.cs
@@ -57,17 +57,49 @@ internal class GenerateCodeForOrleansSerializers
                   
               {{accessor}} sealed class {{unescapedWrapperName}}OrleansSerializer : global::Orleans.Serialization.Codecs.IFieldCodec<{{item.VoTypeName}}>
               {
+                  private readonly global::System.Type CodecFieldType = typeof({{underlyingTypeName}});
+
                   public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, System.Type expectedType, {{item.VoTypeName}} value)
                       where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
                   {
+                      global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(writer.Session);
+                      writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof({{item.VoTypeName}}), global::Orleans.Serialization.WireProtocol.WireType.TagDelimited);
+
                       var baseCodec = writer.Session.CodecProvider.GetCodec<{{underlyingTypeName}}>();
-                      baseCodec.WriteField(ref writer, fieldIdDelta, typeof({{underlyingTypeName}}), value.Value);
+                      baseCodec.WriteField(ref writer, 0, CodecFieldType, value.Value);
+                      writer.WriteEndObject();
                   }
-              
+               
                   public {{item.VoTypeName}} ReadValue<TInput>(ref global::Orleans.Serialization.Buffers.Reader<TInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
                   {
+                      field.EnsureWireTypeTagDelimited();
+                      global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(reader.Session);
+
                       var baseCodec = reader.Session.CodecProvider.GetCodec<{{underlyingTypeName}}>();
-                      var baseValue = baseCodec.ReadValue(ref reader, field);
+                      var baseValue = default({{underlyingTypeName}});
+                      uint fieldId = 0;
+
+                      while (true)
+                      {
+                          var header = global::Orleans.Serialization.Codecs.FieldHeaderCodec.ReadFieldHeader(ref reader);
+
+                          if (header.IsEndBaseOrEndObject)
+                          {
+                              break;
+                          }
+
+                          fieldId += header.FieldIdDelta;
+                          
+                          if (fieldId == 0)
+                          {
+                              baseValue = baseCodec.ReadValue(ref reader, header);
+                          }
+                          else
+                          {
+                              global::Orleans.Serialization.Codecs.ConsumeFieldExtension.ConsumeUnknownField(ref reader, header);
+                          }
+                      }
+
                       return UnsafeDeserialize(default, baseValue);
                   }
                   

--- a/tests/SnapshotTests/OrleansGeneration/snapshots/snap-v8.0/OrleansGenerationTests.Escapes_wrapper_name.verified.txt
+++ b/tests/SnapshotTests/OrleansGeneration/snapshots/snap-v8.0/OrleansGenerationTests.Escapes_wrapper_name.verified.txt
@@ -35,17 +35,49 @@ namespace @class.@struct.@record;
     
 internal sealed class classOrleansSerializer : global::Orleans.Serialization.Codecs.IFieldCodec<@class>
 {
+    private readonly global::System.Type CodecFieldType = typeof(global::System.Int32);
+
     public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, System.Type expectedType, @class value)
         where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
     {
-        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.Int32>();
-        baseCodec.WriteField(ref writer, fieldIdDelta, typeof(global::System.Int32), value.Value);
-    }
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(@class), global::Orleans.Serialization.WireProtocol.WireType.TagDelimited);
 
+        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.Int32>();
+        baseCodec.WriteField(ref writer, 0, CodecFieldType, value.Value);
+        writer.WriteEndObject();
+    }
+ 
     public @class ReadValue<TInput>(ref global::Orleans.Serialization.Buffers.Reader<TInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
     {
+        field.EnsureWireTypeTagDelimited();
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(reader.Session);
+
         var baseCodec = reader.Session.CodecProvider.GetCodec<global::System.Int32>();
-        var baseValue = baseCodec.ReadValue(ref reader, field);
+        var baseValue = default(global::System.Int32);
+        uint fieldId = 0;
+
+        while (true)
+        {
+            var header = global::Orleans.Serialization.Codecs.FieldHeaderCodec.ReadFieldHeader(ref reader);
+
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            
+            if (fieldId == 0)
+            {
+                baseValue = baseCodec.ReadValue(ref reader, header);
+            }
+            else
+            {
+                global::Orleans.Serialization.Codecs.ConsumeFieldExtension.ConsumeUnknownField(ref reader, header);
+            }
+        }
+
         return UnsafeDeserialize(default, baseValue);
     }
     

--- a/tests/SnapshotTests/OrleansGeneration/snapshots/snap-v8.0/OrleansGenerationTests.Generates_if_global_attribute_set.verified.txt
+++ b/tests/SnapshotTests/OrleansGeneration/snapshots/snap-v8.0/OrleansGenerationTests.Generates_if_global_attribute_set.verified.txt
@@ -35,17 +35,49 @@ namespace OrleansTests;
     
 public sealed class AgeOrleansSerializer : global::Orleans.Serialization.Codecs.IFieldCodec<Age>
 {
+    private readonly global::System.Type CodecFieldType = typeof(global::System.Int32);
+
     public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, System.Type expectedType, Age value)
         where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
     {
-        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.Int32>();
-        baseCodec.WriteField(ref writer, fieldIdDelta, typeof(global::System.Int32), value.Value);
-    }
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Age), global::Orleans.Serialization.WireProtocol.WireType.TagDelimited);
 
+        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.Int32>();
+        baseCodec.WriteField(ref writer, 0, CodecFieldType, value.Value);
+        writer.WriteEndObject();
+    }
+ 
     public Age ReadValue<TInput>(ref global::Orleans.Serialization.Buffers.Reader<TInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
     {
+        field.EnsureWireTypeTagDelimited();
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(reader.Session);
+
         var baseCodec = reader.Session.CodecProvider.GetCodec<global::System.Int32>();
-        var baseValue = baseCodec.ReadValue(ref reader, field);
+        var baseValue = default(global::System.Int32);
+        uint fieldId = 0;
+
+        while (true)
+        {
+            var header = global::Orleans.Serialization.Codecs.FieldHeaderCodec.ReadFieldHeader(ref reader);
+
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            
+            if (fieldId == 0)
+            {
+                baseValue = baseCodec.ReadValue(ref reader, header);
+            }
+            else
+            {
+                global::Orleans.Serialization.Codecs.ConsumeFieldExtension.ConsumeUnknownField(ref reader, header);
+            }
+        }
+
         return UnsafeDeserialize(default, baseValue);
     }
     
@@ -109,17 +141,49 @@ namespace OrleansTests;
     
 public sealed class NameOrleansSerializer : global::Orleans.Serialization.Codecs.IFieldCodec<Name>
 {
+    private readonly global::System.Type CodecFieldType = typeof(global::System.String);
+
     public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, System.Type expectedType, Name value)
         where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
     {
-        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.String>();
-        baseCodec.WriteField(ref writer, fieldIdDelta, typeof(global::System.String), value.Value);
-    }
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Name), global::Orleans.Serialization.WireProtocol.WireType.TagDelimited);
 
+        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.String>();
+        baseCodec.WriteField(ref writer, 0, CodecFieldType, value.Value);
+        writer.WriteEndObject();
+    }
+ 
     public Name ReadValue<TInput>(ref global::Orleans.Serialization.Buffers.Reader<TInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
     {
+        field.EnsureWireTypeTagDelimited();
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(reader.Session);
+
         var baseCodec = reader.Session.CodecProvider.GetCodec<global::System.String>();
-        var baseValue = baseCodec.ReadValue(ref reader, field);
+        var baseValue = default(global::System.String);
+        uint fieldId = 0;
+
+        while (true)
+        {
+            var header = global::Orleans.Serialization.Codecs.FieldHeaderCodec.ReadFieldHeader(ref reader);
+
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            
+            if (fieldId == 0)
+            {
+                baseValue = baseCodec.ReadValue(ref reader, header);
+            }
+            else
+            {
+                global::Orleans.Serialization.Codecs.ConsumeFieldExtension.ConsumeUnknownField(ref reader, header);
+            }
+        }
+
         return UnsafeDeserialize(default, baseValue);
     }
     

--- a/tests/SnapshotTests/OrleansGeneration/snapshots/snap-v8.0/OrleansGenerationTests.Generates_if_local_attribute_set.verified.txt
+++ b/tests/SnapshotTests/OrleansGeneration/snapshots/snap-v8.0/OrleansGenerationTests.Generates_if_local_attribute_set.verified.txt
@@ -35,17 +35,49 @@ namespace OrleansTests;
     
 public sealed class AgeOrleansSerializer : global::Orleans.Serialization.Codecs.IFieldCodec<Age>
 {
+    private readonly global::System.Type CodecFieldType = typeof(global::System.Int32);
+
     public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, System.Type expectedType, Age value)
         where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
     {
-        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.Int32>();
-        baseCodec.WriteField(ref writer, fieldIdDelta, typeof(global::System.Int32), value.Value);
-    }
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Age), global::Orleans.Serialization.WireProtocol.WireType.TagDelimited);
 
+        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.Int32>();
+        baseCodec.WriteField(ref writer, 0, CodecFieldType, value.Value);
+        writer.WriteEndObject();
+    }
+ 
     public Age ReadValue<TInput>(ref global::Orleans.Serialization.Buffers.Reader<TInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
     {
+        field.EnsureWireTypeTagDelimited();
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(reader.Session);
+
         var baseCodec = reader.Session.CodecProvider.GetCodec<global::System.Int32>();
-        var baseValue = baseCodec.ReadValue(ref reader, field);
+        var baseValue = default(global::System.Int32);
+        uint fieldId = 0;
+
+        while (true)
+        {
+            var header = global::Orleans.Serialization.Codecs.FieldHeaderCodec.ReadFieldHeader(ref reader);
+
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            
+            if (fieldId == 0)
+            {
+                baseValue = baseCodec.ReadValue(ref reader, header);
+            }
+            else
+            {
+                global::Orleans.Serialization.Codecs.ConsumeFieldExtension.ConsumeUnknownField(ref reader, header);
+            }
+        }
+
         return UnsafeDeserialize(default, baseValue);
     }
     
@@ -109,17 +141,49 @@ namespace OrleansTests;
     
 public sealed class NameOrleansSerializer : global::Orleans.Serialization.Codecs.IFieldCodec<Name>
 {
+    private readonly global::System.Type CodecFieldType = typeof(global::System.String);
+
     public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, System.Type expectedType, Name value)
         where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
     {
-        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.String>();
-        baseCodec.WriteField(ref writer, fieldIdDelta, typeof(global::System.String), value.Value);
-    }
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Name), global::Orleans.Serialization.WireProtocol.WireType.TagDelimited);
 
+        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.String>();
+        baseCodec.WriteField(ref writer, 0, CodecFieldType, value.Value);
+        writer.WriteEndObject();
+    }
+ 
     public Name ReadValue<TInput>(ref global::Orleans.Serialization.Buffers.Reader<TInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
     {
+        field.EnsureWireTypeTagDelimited();
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(reader.Session);
+
         var baseCodec = reader.Session.CodecProvider.GetCodec<global::System.String>();
-        var baseValue = baseCodec.ReadValue(ref reader, field);
+        var baseValue = default(global::System.String);
+        uint fieldId = 0;
+
+        while (true)
+        {
+            var header = global::Orleans.Serialization.Codecs.FieldHeaderCodec.ReadFieldHeader(ref reader);
+
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            
+            if (fieldId == 0)
+            {
+                baseValue = baseCodec.ReadValue(ref reader, header);
+            }
+            else
+            {
+                global::Orleans.Serialization.Codecs.ConsumeFieldExtension.ConsumeUnknownField(ref reader, header);
+            }
+        }
+
         return UnsafeDeserialize(default, baseValue);
     }
     

--- a/tests/SnapshotTests/OrleansGeneration/snapshots/snap-v8.0/OrleansGenerationTests.Takes_on_accessibility_of_value_object.verified.txt
+++ b/tests/SnapshotTests/OrleansGeneration/snapshots/snap-v8.0/OrleansGenerationTests.Takes_on_accessibility_of_value_object.verified.txt
@@ -35,17 +35,49 @@ namespace OrleansTests;
     
 internal sealed class AgeOrleansSerializer : global::Orleans.Serialization.Codecs.IFieldCodec<Age>
 {
+    private readonly global::System.Type CodecFieldType = typeof(global::System.Int32);
+
     public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, System.Type expectedType, Age value)
         where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
     {
-        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.Int32>();
-        baseCodec.WriteField(ref writer, fieldIdDelta, typeof(global::System.Int32), value.Value);
-    }
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Age), global::Orleans.Serialization.WireProtocol.WireType.TagDelimited);
 
+        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.Int32>();
+        baseCodec.WriteField(ref writer, 0, CodecFieldType, value.Value);
+        writer.WriteEndObject();
+    }
+ 
     public Age ReadValue<TInput>(ref global::Orleans.Serialization.Buffers.Reader<TInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
     {
+        field.EnsureWireTypeTagDelimited();
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(reader.Session);
+
         var baseCodec = reader.Session.CodecProvider.GetCodec<global::System.Int32>();
-        var baseValue = baseCodec.ReadValue(ref reader, field);
+        var baseValue = default(global::System.Int32);
+        uint fieldId = 0;
+
+        while (true)
+        {
+            var header = global::Orleans.Serialization.Codecs.FieldHeaderCodec.ReadFieldHeader(ref reader);
+
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            
+            if (fieldId == 0)
+            {
+                baseValue = baseCodec.ReadValue(ref reader, header);
+            }
+            else
+            {
+                global::Orleans.Serialization.Codecs.ConsumeFieldExtension.ConsumeUnknownField(ref reader, header);
+            }
+        }
+
         return UnsafeDeserialize(default, baseValue);
     }
     
@@ -109,17 +141,49 @@ namespace OrleansTests;
     
 public sealed class NameOrleansSerializer : global::Orleans.Serialization.Codecs.IFieldCodec<Name>
 {
+    private readonly global::System.Type CodecFieldType = typeof(global::System.String);
+
     public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, System.Type expectedType, Name value)
         where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
     {
-        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.String>();
-        baseCodec.WriteField(ref writer, fieldIdDelta, typeof(global::System.String), value.Value);
-    }
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(writer.Session);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(Name), global::Orleans.Serialization.WireProtocol.WireType.TagDelimited);
 
+        var baseCodec = writer.Session.CodecProvider.GetCodec<global::System.String>();
+        baseCodec.WriteField(ref writer, 0, CodecFieldType, value.Value);
+        writer.WriteEndObject();
+    }
+ 
     public Name ReadValue<TInput>(ref global::Orleans.Serialization.Buffers.Reader<TInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
     {
+        field.EnsureWireTypeTagDelimited();
+        global::Orleans.Serialization.Codecs.ReferenceCodec.MarkValueField(reader.Session);
+
         var baseCodec = reader.Session.CodecProvider.GetCodec<global::System.String>();
-        var baseValue = baseCodec.ReadValue(ref reader, field);
+        var baseValue = default(global::System.String);
+        uint fieldId = 0;
+
+        while (true)
+        {
+            var header = global::Orleans.Serialization.Codecs.FieldHeaderCodec.ReadFieldHeader(ref reader);
+
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            
+            if (fieldId == 0)
+            {
+                baseValue = baseCodec.ReadValue(ref reader, header);
+            }
+            else
+            {
+                global::Orleans.Serialization.Codecs.ConsumeFieldExtension.ConsumeUnknownField(ref reader, header);
+            }
+        }
+
         return UnsafeDeserialize(default, baseValue);
     }
     


### PR DESCRIPTION
Emit tag-delimited Orleans payloads for generated VO codecs so nullable ValueObject<string> fields deserialize correctly.

Fixes #887 